### PR TITLE
use new Janus permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We're using [pan-domain-authentication] to handle authentication.
 We're only verifying a pan domain cookie. Cookies are issued by [login.gutools].
 [login.gutools] requires credentials to access the relevant AWS resources.
 
-Get `composer` and `workflow` credentials from [Janus][janus-credentials].
+Get credentials from [Janus][janus-credentials].
 
 ### Setup
 By now you should have all dependencies installed.
@@ -97,7 +97,7 @@ ParcelJS will output the built app to Play's [public][directory-public] director
 [file-script-test]: ./scripts/test
 [fnm]: https://github.com/Schniz/fnm
 [guardian-source]: https://github.com/guardian/source
-[janus-credentials]: https://janus.gutools.co.uk/multi-credentials?&permissionIds=composer-dev,workflow-dev&tzOffset=1
+[janus-credentials]: https://janus.gutools.co.uk/credentials?permissionId=composer-login-local-dev&tzOffset=1
 [login.gutools]: https://github.com/guardian/login.gutools
 [nvm]: https://github.com/nvm-sh/nvm
 [pan-domain-authentication]: https://github.com/guardian/pan-domain-authentication


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We've created a new permission in Janus which gives access to the specific resources needed for login.gutools. This has resulted in needing a single set of Janus credentials, rather than two.

Follows https://github.com/guardian/login.gutools/pull/48.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Follow the docs to run the app.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler requirements to run the app locally.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
n/a