### PR TITLE
API endpoints: list recipes, get recipe ids for path

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -20,6 +20,8 @@ class Config(playConfig: Configuration) extends Logging {
   lazy val stack: String = playConfig.get[String]("stack")
   lazy val app: String = playConfig.get[String]("app")
   lazy val tableName: String = playConfig.get[String]("tableName")
+  lazy val hashKey: String = playConfig.get[String]("hashKey")
+  lazy val rangeKey: String = playConfig.get[String]("rangeKey")
 
   final lazy val stage: Stage = {
     val stageFilePath: String = "/etc/gu/stage"

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -18,6 +18,17 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.amazonaws.services.dynamodbv2.document.ItemUtils
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest
+import play.api.libs.json.JsPath
+import java.util.ArrayList
+import com.amazonaws.services.dynamodbv2.document.Item
+// import com.amazonaws.services.dynamodbv2.datamodeling.DomainObject;
 // import com.amazonaws.services.dynamodbv2.Ama
 //, DynamoDB, Item, ItemCollection, QueryOutcome, Table}
 // import com.amazonaws.services.dynamodbv2.spec.QuerySpec;
@@ -37,6 +48,11 @@ class ApiController (
    * will be called when the application receives a `GET` request with
    * a path of `/`.
    */
+
+  // Utility functions
+  def isEmpty(x: String) = x == null || x.isEmpty
+
+  // Endpoint functions
 
   def postId(id: String) = Action { implicit request =>
       Ok("{Request [" + request + "] for '"+id+"'.")
@@ -440,8 +456,6 @@ class ApiController (
   }
 
   def db(id: String) = Action {
-    def isEmpty(x: String) = x == null || x.isEmpty
-    logger.info("%s is null? %s".format(config.dbUrl, isEmpty(config.dbUrl).toString()))
     val dbClient = config.dbUrl match {
       case _ if isEmpty(config.dbUrl) => AmazonDynamoDBClientBuilder.standard()
                   .withCredentials(config.awsCredentials)
@@ -452,8 +466,8 @@ class ApiController (
                   .build()
     }
 
-    val key_to_get = MMap("path" -> new AttributeValue("/"+id),
-                          "recipeId" -> new AttributeValue().withN("1")
+    val key_to_get = MMap(config.hashKey -> new AttributeValue("/"+id),
+                          config.rangeKey -> new AttributeValue().withN("1")
                         ).asJava;
 
     val request: GetItemRequest = new GetItemRequest()
@@ -462,9 +476,46 @@ class ApiController (
 
     val data = dbClient.getItem(request).getItem();
     if (data == null) {
-      NotFound("No recipe with path: '%s' and id: '%s'.".format(id, "1"))
+      NotFound("No recipe with %s: '%s' and id: '%s'.".format(config.hashKey, id, "1"))
     } else {
       Ok(Json.parse(ItemUtils.toItem(data).toJSON()));
+    }
+  }
+
+  def list(id: String) = Action {
+    // List all recipes available for `path`
+    val dbClient = config.dbUrl match {
+      case _ if isEmpty(config.dbUrl) => AmazonDynamoDBClientBuilder.standard()
+                  .withCredentials(config.awsCredentials)
+                  .build()
+      case _ => AmazonDynamoDBClientBuilder.standard()
+                  .withCredentials(config.awsCredentials)
+                  .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.dbUrl, "eu-west-1"))
+                  .build()
+    }
+    val partition_alias = "#p";
+    val range_alias = ":r";
+    val recipes_key = MMap(partition_alias -> config.hashKey).asJava;
+    val recipes_to_get = MMap(":"+config.hashKey -> new AttributeValue("/"+id)).asJava;
+
+    val queryExpression = new QueryRequest()
+      .withTableName(config.tableName)
+      .withKeyConditionExpression(partition_alias+ " = :path")
+      .withExpressionAttributeNames(recipes_key)
+      .withExpressionAttributeValues(recipes_to_get)
+
+    val recipeResult = dbClient.query(queryExpression)
+    println(recipeResult.getCount())
+
+    if (recipeResult == null) {
+      NotFound("No recipe with %s: '%s'.".format(config.hashKey, id))
+    } else {
+      val data = ItemUtils.toItemList(recipeResult.getItems()).asScala
+
+      val response = Json.toJson(data.map(
+        i => Json.parse(i.toJSON())
+      ))
+      Ok(response);
     }
   }
 }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -551,7 +551,6 @@ class ApiController (
       .withExpressionAttributeValues(recipes_to_get)
 
     val recipeResult = dbClient.query(queryExpression)
-    println(recipeResult.getCount())
 
     if (recipeResult == null) {
       NotFound("No recipe with %s: '%s'.".format(config.hashKey, id))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,6 +3,8 @@ play.application.loader= AppLoader
 stack = "flexible"
 app = "recipes"
 tableName = "recipes"
+hashKey = "path"
+rangeKey = "recipeId"
 
 play {
   filters {

--- a/conf/routes
+++ b/conf/routes
@@ -6,11 +6,12 @@
 GET     /                           controllers.HomeController.index(id = "")
 GET     /curation/*id               controllers.HomeController.index(id)
 GET     /api/curation/schema        controllers.ApiController.schema
-GET     /api/db/*id                 controllers.ApiController.db(id)
-GET     /api/list/*id               controllers.ApiController.list(id)
 GET     /api/curation/*id           controllers.ApiController.index(id)
 +nocsrf
 POST    /api/curation/*id           controllers.ApiController.postId(id)
+GET     /api/db/*id                 controllers.ApiController.db(id)
+GET     /api/list                   controllers.ApiController.get_list
+GET     /api/list/*id               controllers.ApiController.list(id)
 
 GET     /management/manifest        controllers.ManagementController.manifest
 GET     /management/healthcheck     controllers.ManagementController.healthCheck

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET     /                           controllers.HomeController.index(id = "")
 GET     /curation/*id               controllers.HomeController.index(id)
 GET     /api/curation/schema        controllers.ApiController.schema
 GET     /api/db/*id                 controllers.ApiController.db(id)
+GET     /api/list/*id               controllers.ApiController.list(id)
 GET     /api/curation/*id           controllers.ApiController.index(id)
 +nocsrf
 POST    /api/curation/*id           controllers.ApiController.postId(id)


### PR DESCRIPTION
## What does this change?
Adds endpoint to list recipe ids given `path`
Adds endpoint to get recipe data given `path`
Endpoint can now cope with `path`_`id` structure and correctly select recipe of article.

## How to test
Run locally and `GET`:
`https://recipes.local.dev-gutools.co.uk/api/list/lifeandstyle/2012/jun/15/lettuce-recipes-hugh-fearnley-whittingstall`
`https://recipes.local.dev-gutools.co.uk/api/list`
`https://recipes.local.dev-gutools.co.uk/api/db/lifeandstyle/2012/jun/15/lettuce-recipes-hugh-fearnley-whittingstall_2`


## How can we measure success?
Does it serve the correct recipe?

## Have we considered potential risks?
Yep
