### PR TITLE
Add permissions for wazuh agent

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -112,7 +112,22 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
-
+              
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref AppRole 
   GetDistributablesPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -127,7 +127,7 @@ Resources:
           - autoscaling:DescribeAutoScalingGroups
           - autoscaling:DescribeAutoScalingInstances
       Roles:
-      - !Ref AppRole 
+        - !Ref AppRole 
   GetDistributablesPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
## What does this change?
This PR adds some actions to the recipes cfn, required for Wazuh to function correctly. The image already contains the agent required (`editorial-tools-xenial-java8`)

[Guardian Wazuh guide](https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md)

## How to test
Deploy to CODE, check Wazuh is reporting healthy by using SSM:
```ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep Valid" -t <app tag>,CODE -p media-service```

