### PR TITLE
Add Wazuh security group

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -80,6 +80,7 @@ Resources:
       IamInstanceProfile: !Ref InstanceProfile
       SecurityGroups:
         - !Ref InstanceSecurityGroup
+        - !Ref WazuhSecurityGroup
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -321,6 +322,17 @@ Resources:
           FromPort: 9000
           ToPort: 9000
           CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
+        CidrIp: 0.0.0.0/0
 
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
## What does this change?

#23 neglected to add a security group allowing the [appropriate egress](https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md) for Wazuh. This PR adds it.

## How to test

Issuing the following command should show a healthy agent on each box. (For some reason, the tag lookup doesn't work!)

```ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent" -i <instanceIds> -p composer```


<details>
    <summary>Tested in PROD (in the absence of a CODE or equivalent)</summary>

```
========= i-xxx =========
STDOUT:
   Active: active (running) since Thu 2021-04-08 17:09:10 UTC; 1min 36s ago
Apr 08 17:09:03 ip-10-248-203-248 authenticate-with-wazuh-manager.sh[1178]: 2021/04/08 17:09:03 agent-auth: INFO: Valid key created. Finished.

STDERR:

========= i-xxx =========
STDOUT:
   Active: active (running) since Thu 2021-04-08 17:09:15 UTC; 1min 31s ago
Apr 08 17:09:08 ip-10-248-205-50 authenticate-with-wazuh-manager.sh[1135]: 2021/04/08 17:09:08 agent-auth: INFO: Valid key created. Finished.

STDERR:

========= i-xxx =========
STDOUT:
   Active: active (running) since Thu 2021-04-08 17:09:16 UTC; 1min 31s ago
Apr 08 17:09:09 ip-10-248-206-213 authenticate-with-wazuh-manager.sh[1159]: 2021/04/08 17:09:09 agent-auth: INFO: Valid key created. Finished.

STDERR:
```

</details>
