### PR TITLE
Add imdsv2 to instance profile

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -78,6 +78,8 @@ Resources:
       ImageId: !Ref AMI
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       IamInstanceProfile: !Ref InstanceProfile
+      MetadataOptions:
+        HttpTokens: required
       SecurityGroups:
         - !Ref InstanceSecurityGroup
         - !Ref WazuhSecurityGroup


### PR DESCRIPTION
## What does this change?

Alters the project CFN to use [IMDSv2](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md)

## How to test

The app should work as before. When deployed, IMDSv1 usage should stop.


