### PR TITLE
Add table for edited recipes

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -38,6 +38,10 @@ Parameters:
     Description: Name of table to store recipes in.
     Type: String
     Default: recipes
+  EditedRecipesTable:
+    Description: Name of table to store edited recipes in.
+    Type: String
+    Default: recipes
 
 Mappings:
   StageVariables:
@@ -115,7 +119,7 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
-              
+
   DescribeEC2Policy:
     Type: AWS::IAM::Policy
     Properties:
@@ -130,7 +134,7 @@ Resources:
           - autoscaling:DescribeAutoScalingGroups
           - autoscaling:DescribeAutoScalingInstances
       Roles:
-        - !Ref AppRole 
+        - !Ref AppRole
   GetDistributablesPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -379,6 +383,24 @@ Resources:
         KeyType: HASH
       - AttributeName: recipeId
         KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+
+  EditedRecipesDynamoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref EditedRecipesTable
+      AttributeDefinitions:
+        - AttributeName: path
+          AttributeType: S
+        - AttributeName: recipeId
+          AttributeType: N
+      KeySchema:
+        - AttributeName: path
+          KeyType: HASH
+        - AttributeName: recipeId
+          KeyType: RANGE
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1


### PR DESCRIPTION
Following a discussion with @michel-ds we need a way of preserviing the original recipe that was imported into the app. One way of doing this is to store all edits in a separate table, then in the backend when a recipe is loaded to fetch it from the edited table if it's available, and from the other table if not. All writes go to the edited table. 

This is a proposal as much as a PR, happy to hear other options