### PR TITLE
Remove bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,6 @@ lazy val root = (project in file("."))
       BuildInfoOption.ToJson
     ),
 
-    resolvers ++= Seq(
-      "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-    ),
     libraryDependencies ++= Seq(
       ws,
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test,
@@ -77,4 +74,3 @@ lazy val root = (project in file("."))
     ),
     javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
   ))
-

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "com.gu" %% "pan-domain-auth-verification" % "1.0.4",
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
-      "com.gu" %% "simple-configuration-s3" % "1.5.2"
+      "com.gu" %% "simple-configuration-s3" % "1.5.5"
     ),
     scalacOptions ++= List(
       "-encoding", "utf8",


### PR DESCRIPTION
## What does this change?
1. Removes Bintray resolver
2. Bumps `simple-configuration-s3` to v. 1.5.5 (version on Sonatype)
3. Adds AWS SDK v2 as required by `simple-configuration-s3`.

Passes all tests run locally. Builds successfully on Teamcity.

## How to test
Build the project locally and see that it runs.
