### PR TITLE
Fix: Rename edited recipes table to avoid duplication.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -41,7 +41,7 @@ Parameters:
   EditedRecipesTable:
     Description: Name of table to store edited recipes in.
     Type: String
-    Default: recipes
+    Default: recipes-edited
 
 Mappings:
   StageVariables:


### PR DESCRIPTION
## What does this change?
Bug fix. 
Rename the table that stores edited recipes. The recipe and edited recipe tables were previously called the same name which triggered the following error during deploy.
```
EditedRecipesDynamoTable(AWS::DynamoDB::Table}: CREATE_FAILED recipes already exists in stack arn:aws:cloudformation:eu-west-1:743583969668:stack/recipes-PROD/8fda9450-edbd-11ea-9a83-0655dfaca74c
```

## How to test
Does it deploy without error and create two dynamoDB tables?

## How can we measure success?
App properly deployed again.

## Have we considered potential risks?
✔️ 

## Images
No UI changes.