### PR TITLE
Add deletionpolicy to prevent data loss

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -370,6 +370,7 @@ Resources:
           Value: !Ref App
 
   RecipesDynamoTable:
+    DeletionPolicy: Retain
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref RecipesTable
@@ -388,6 +389,7 @@ Resources:
         WriteCapacityUnits: 1
 
   EditedRecipesDynamoTable:
+  DeletionPolicy: Retain
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref EditedRecipesTable


### PR DESCRIPTION
## What does this change?
Adds a [deletion policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) to prevent accidental data loss from stack deletion