### PR TITLE
 Updates to sbt and log4j due to vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.gu.riffraff.artifact.BuildInfo
 
 val enumeratumVersion = "1.6.1"
 val jacksonVersion = "2.10.5"
-val logstashLogbackVersion = "6.4"
+val logstashLogbackVersion = "7.0.1"
 val awsSdkVersion = "1.11.851"
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file("."))
     PlayKeys.playDefaultPort := 9090,
 
     riffRaffArtifactResources := Seq(
-      (packageBin in Debian).value -> s"${name.value}/${name.value}.deb",
+      (Debian / packageBin).value -> s"${name.value}/${name.value}.deb",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
       baseDirectory.value / "cloudformation.yaml" -> "cloudformation/recipes.cfn.yaml"
     ),
@@ -64,7 +64,7 @@ lazy val root = (project in file("."))
     dependencyOverrides ++= Seq(
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5",
     ),
-    javaOptions in Universal ++= Seq(
+    Universal / javaOptions ++= Seq(
       s"-Dpidfile.path=/dev/null",
       "-J-XX:MaxRAMFraction=2",
       "-J-XX:InitialRAMFraction=2",
@@ -75,5 +75,5 @@ lazy val root = (project in file("."))
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
       "-Dconfig.file=/etc/gu/recipes.conf"
     ),
-    javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
+    Test / javaOptions += "-Dconfig.file=conf/application.test.conf"
   ))

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import com.gu.riffraff.artifact.BuildInfo
 
 val enumeratumVersion = "1.6.1"
-val jacksonVersion = "2.10.5"
-val logstashLogbackVersion = "7.0.1"
+val jacksonVersion = "2.11.4"
+val logstashLogbackVersion = "6.4"
 val awsSdkVersion = "1.11.851"
 
 lazy val root = (project in file("."))
@@ -62,7 +62,7 @@ lazy val root = (project in file("."))
       "-Xfatal-warnings"
     ),
     dependencyOverrides ++= Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5",
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
     ),
     Universal / javaOptions ++= Seq(
       s"-Dpidfile.path=/dev/null",

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.gu.riffraff.artifact.BuildInfo
 
 val enumeratumVersion = "1.6.1"
 val jacksonVersion = "2.11.4"
-val logstashLogbackVersion = "6.4"
+val logstashLogbackVersion = "7.0.1"
 val awsSdkVersion = "1.11.851"
 
 lazy val root = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 


### PR DESCRIPTION
On 9 Dec 2021, a popular Java logging library log4j was discovered that
results in Remote Code Execution (RCE) by logging a certain string.
Here is helpful information on how the exploit works:
https://www.lunasec.io/docs/blog/log4j-zero-day/#how-the-exploit-works.

This Google doc explains how to secure our apps:
https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo/edit#

## What does this change?

Bumps `sbt` and `logstash-logback-encoder` to fix log4j vulnerability described above.

## How to test

Follow installation instructions in `README.md` and run `sbt run` which should output the following line
```[info] welcome to sbt 1.5.7 ```


## How can we measure success?

Does it still deploy successfully?

## Have we considered potential risks?

I can still find mentions of log4j versions < 6.8.21 in the `classpath` in the `project/.bloop/curationui-build.json` file after building so I would be grateful @akash1810 if you could advise.
```
       "classpath": [
           ...
            "/Users/michel_schammel/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar",
            "/Users/michel_schammel/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar",
            "/Users/michel_schammel/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.15.0/log4j-slf4j-impl-2.15.0.jar",
```
