### PR TITLE
Reduce minimum ASG size to zero

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,7 +47,7 @@ Mappings:
   StageVariables:
     PROD:
       MaxInstances: 6
-      MinInstances: 3
+      MinInstances: 0
       InstanceType: t3.small
       Domain: recipes.gutools.co.uk
 


### PR DESCRIPTION
Reduce minimum ASG size to zero since we have agreed that this app will be scaled down to zero most of the time.  I have also disabled the riff-raff scheduled deploy to avoid accidental increases in the number of running instances.