### PR TITLE
Remove old BuildInfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
       # Required for `actions/checkout`
       contents: read
     steps:
-      - name: Set BUILD_NUMBER environment variable
-        run: |
-          LAST_TEAMCITY_BUILD=215
-          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -44,7 +40,6 @@ jobs:
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: editorial-tools::recipes
-          buildNumber: ${{ env.BUILD_NUMBER }}
           configPath: riff-raff.yaml
           contentDirectories: |
             cloudformation:

--- a/app/controllers/ManagementController.scala
+++ b/app/controllers/ManagementController.scala
@@ -5,9 +5,6 @@ import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
 
 class ManagementController (override val controllerComponents: ControllerComponents) extends BaseController with Logging {
-  def manifest = Action {
-    Ok(Json.parse(recipes.BuildInfo.toJson))
-  }
 
   def disallowRobots = Action {
     Ok("User-agent: *\nDisallow: /\n")

--- a/app/logging/LogConfig.scala
+++ b/app/logging/LogConfig.scala
@@ -32,8 +32,7 @@ object LogConfig {
       "stack" -> config.stack,
       "stage" -> config.stage.toString.toUpperCase,
       "app" -> config.app,
-      "region" -> config.awsRegion.getName,
-      "buildNumber" -> recipes.BuildInfo.buildNumber
+      "region" -> config.awsRegion.getName
     )).toString()
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,30 +6,13 @@ val logstashLogbackVersion = "7.0.1"
 val awsSdkVersion = "1.11.851"
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
+  .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin)
   .settings(Seq(
     name := """recipes""",
     version := "1.0-SNAPSHOT",
     scalaVersion := "2.13.1",
 
     PlayKeys.playDefaultPort := 9090,
-
-    buildInfoPackage := "recipes",
-    buildInfoKeys := {
-      lazy val buildInfo = BuildInfo(baseDirectory.value)
-      Seq[BuildInfoKey](
-        BuildInfoKey.sbtbuildinfoConstantEntry("buildNumber", buildInfo.buildIdentifier),
-        // so this next one is constant to avoid it always recompiling on dev machines.
-        // we only really care about build time on teamcity, when a constant based on when
-        // it was loaded is just fine
-        BuildInfoKey.sbtbuildinfoConstantEntry("buildTime", System.currentTimeMillis),
-        BuildInfoKey.sbtbuildinfoConstantEntry("gitCommitId", buildInfo.revision)
-      )
-    },
-    buildInfoOptions:= Seq(
-      BuildInfoOption.Traits("management.BuildInfo"),
-      BuildInfoOption.ToJson
-    ),
 
     libraryDependencies ++= Seq(
       ws,

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,6 @@ GET     /api/db/*id                 controllers.ApiController.db(id)
 GET     /api/list                   controllers.ApiController.get_list
 GET     /api/list/*id               controllers.ApiController.list(id)
 
-GET     /management/manifest        controllers.ManagementController.manifest
 GET     /management/healthcheck     controllers.ManagementController.healthCheck
 GET     /robots.txt                 controllers.ManagementController.disallowRobots
 

--- a/scripts/ci-sbt
+++ b/scripts/ci-sbt
@@ -2,4 +2,4 @@
 
 set -e
 
-sbt clean compile test Debian/packageBin riffRaffPackageName
+sbt clean compile test Debian/packageBin


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

My bad. Forgot that `BuildInfo` is no longer available after stripping out the riff-raff artifact library, hence removing obsolete references to BuilInfo.

