### PR TITLE
Check both raw and curated tables in appropriate API requests

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -502,7 +502,7 @@ class ApiController (
 
     val scanRequest = new ScanRequest()
         .withTableName(config.rawRecipesTableName)
-        .withProjectionExpression("%s, title, contributors, canonicalArticle".format(partition_alias))
+        .withProjectionExpression("%s, title, contributors, canonicalArticle, isAppReady".format(partition_alias))
         .withExpressionAttributeNames(expressionAttributeValues)
         .withLimit(60);
 

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -482,15 +482,23 @@ class ApiController (
 
     val key_to_get = MMap(config.hashKey -> new AttributeValue(id)).asJava;
 
-    val request: GetItemRequest = new GetItemRequest()
-      .withKey(key_to_get)
-      .withTableName(config.rawRecipesTableName);
+    def request(tableName: String) = new GetItemRequest()
+        .withKey(key_to_get)
+        .withTableName(tableName);
 
-    val data = dbClient.getItem(request).getItem();
-    if (data == null) {
+    val rawData = dbClient.getItem(request(config.rawRecipesTableName)).getItem();
+    val curatedData = dbClient.getItem(request(config.curatedRecipesTableName)).getItem();
+
+    val dataToReturn = if (curatedData != null) {
+      curatedData
+    } else {
+      rawData
+    }
+
+    if (dataToReturn == null) {
       NotFound("No recipe with %s: '%s'.".format(config.hashKey, id))
     } else {
-      Ok(Json.parse(ItemUtils.toItem(data).toJSON()));
+      Ok(Json.parse(ItemUtils.toItem(dataToReturn).toJSON()));
     }
   }
 
@@ -500,17 +508,21 @@ class ApiController (
     val partition_alias = "#p";
     val expressionAttributeValues = MMap(partition_alias -> config.hashKey).asJava;
 
-    val scanRequest = new ScanRequest()
-        .withTableName(config.rawRecipesTableName)
+    def scanRequest(tableName: String) = new ScanRequest()
+        .withTableName(tableName)
         .withProjectionExpression("%s, title, contributors, canonicalArticle, isAppReady".format(partition_alias))
         .withExpressionAttributeNames(expressionAttributeValues)
         .withLimit(60);
 
+    val rawResult = dbClient.scan(scanRequest( config.rawRecipesTableName ));
+    val rawResultData = ItemUtils.toItemList(rawResult.getItems()).asScala
 
-    val result = dbClient.scan(scanRequest);
-    val data = ItemUtils.toItemList(result.getItems()).asScala
+    val curatedResult = dbClient.scan(scanRequest( config.curatedRecipesTableName ));
+    val curatedResultData = ItemUtils.toItemList(curatedResult.getItems()).asScala
 
-      val response = Json.toJson(data.map(
+    val combinedData = rawResultData.filter( i => !curatedResultData.exists( _.getString(config.hashKey) == i.getString(config.hashKey) ) ) ++ curatedResultData
+
+      val response = Json.toJson(combinedData.map(
         i => Json.parse(i.toJSON())
       ))
       Ok(response);

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import scala.collection.immutable.{Map => MMap}
 
 case class Quantity(absolute: Option[String], from: Option[String], to: Option[String])
-case class Range(min: Int, max: Int)
+case class Range(min: Double, max: Double)
 case class Ingredient(name: String, amount: Range, unit: String, ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean])
 case class IngredientsList(recipeSection: String, ingredientsList: List[Ingredient])
 case class Serves(amount: Range, unit: String)

--- a/recipes-client/components/footer.tsx
+++ b/recipes-client/components/footer.tsx
@@ -39,11 +39,12 @@ const cleanRecipe = (data: lingeringFields | null) => {
 	}
 };
 
-async function postRecipe(
+export async function postRecipe(
 	aId: string | null,
 	data: allRecipeFields | null,
 ): Promise<Record<string, unknown>> {
 	// async function postRecipe(aId: string|null, data: Record<string, unknown>|null): Promise<Record<string, unknown>>{
+	console.log('Data: ' + JSON.stringify(data));
 	if (aId === null) {
 		console.warn('No url provided!');
 		return { error: 'No url provided.' };

--- a/recipes-client/components/footer.tsx
+++ b/recipes-client/components/footer.tsx
@@ -4,7 +4,7 @@ import {
 	ActionType,
 	allRecipeFields,
 	IngredientsGroup,
-	lingeringFields,
+	recipeFields,
 	schemaType,
 } from '../interfaces/main';
 import { apiURL } from '../consts';
@@ -22,10 +22,10 @@ interface FooterProps {
 }
 
 // replace nulls with empty list
-const cleanRecipe = (data: lingeringFields | null) => {
+const cleanRecipe = (data: recipeFields | null) => {
 	// const nullableFields = ['cuisineIds', 'celebrationIds'] as Array<keyof recipeMetaFields>
 	if (data !== null) {
-		const out = Object.keys(data).map((field: keyof lingeringFields) => {
+		const out = Object.keys(data).map((field: keyof recipeFields) => {
 			if (['serves', 'image', 'title', 'description'].includes(field)) {
 				return [field, data[field] ? data[field] : ''];
 			} else {

--- a/recipes-client/components/recipe-list.tsx
+++ b/recipes-client/components/recipe-list.tsx
@@ -1,4 +1,11 @@
 /** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
+import {
+	SvgCrossRound,
+	SvgTickRound,
+	SvgExternal,
+} from '@guardian/source-react-components';
 import { curationEndpoint } from '../consts/index';
 
 interface RecipeListProps {
@@ -10,46 +17,94 @@ interface RecipeListType {
 	title: string;
 	contributors: string[];
 	canonicalArticle: string;
+	isAppReady: boolean;
 }
 
 const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 	return (
-		<table>
+		<table css={tableStyles}>
 			<thead>
 				<tr>
-					<th>Title</th>
+					<th>Recipe</th>
 					<th>Author(s)</th>
+					<th>App-ready</th>
 					<th>Actions</th>
 				</tr>
 			</thead>
 			<tbody>
-				{list.map(({ id, title, contributors, canonicalArticle }, i) => {
-					return (
-						<tr key={`row_${i}`}>
-							<td key={`path_${i}_title`}>
-								<a
-									href={`https://theguardian.com/${canonicalArticle}`}
-									target="_blank"
-								>
-									{title}
-								</a>
-							</td>
-							<td key={`path_${i}_author`}> {contributors.join(', ')} </td>
-							<td key={`path_${i}_links`}>
-								<a
-									href={
-										curationEndpoint + '/' + id + '?capiId=' + canonicalArticle
-									}
-								>
-									Edit
-								</a>
-							</td>
-						</tr>
-					);
-				})}
+				{list.map(
+					({ id, title, contributors, canonicalArticle, isAppReady }, i) => {
+						return (
+							<tr key={`row_${i}`}>
+								<td key={`path_${i}_title`}>
+									<a
+										href={`https://theguardian.com/${canonicalArticle}`}
+										target="_blank"
+									>
+										{title}{' '}
+										<SvgExternal isAnnouncedByScreenReader size="xsmall" />
+									</a>
+								</td>
+								<td key={`path_${i}_author`}> {contributors.join(', ')} </td>
+								<td key={`path_${i}_app`}>
+									{isAppReady ? (
+										<span css={tickStyles}>
+											<SvgTickRound isAnnouncedByScreenReader size="small" />
+										</span>
+									) : (
+										<span css={crossStyles}>
+											<SvgCrossRound isAnnouncedByScreenReader size="small" />
+										</span>
+									)}
+								</td>
+								<td key={`path_${i}_links`}>
+									<a
+										href={
+											curationEndpoint +
+											'/' +
+											id +
+											'?capiId=' +
+											canonicalArticle
+										}
+									>
+										Edit
+									</a>
+								</td>
+							</tr>
+						);
+					},
+				)}
 			</tbody>
 		</table>
 	);
 };
+
+const tableStyles = css`
+	width: 100%;
+	border-collapse: collapse;
+	border-spacing: 0;
+	text-align: left;
+	th,
+	td {
+		padding: 0.5rem;
+		border-bottom: 1px solid #ccc;
+	}
+	th {
+		font-weight: bold;
+		background-color: #eee;
+	}
+`;
+
+const tickStyles = css`
+	svg {
+		fill: ${palette.success[500]};
+	}
+`;
+
+const crossStyles = css`
+	svg {
+		fill: ${palette.error[500]};
+	}
+`;
 
 export default RecipeList;

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -21,8 +21,9 @@ const gridLayout = css`
 	display: grid;
 	grid-template-columns: 25% 25% 25% 25%;
 	height: 100vh;
-	grid-template-rows: 30px 1fr 50px;
-	grid-template-areas: 'header header header header' 'left left right right' 'footer footer footer footer';
+	grid-template-rows: 50px 1fr;
+	grid-template-areas: 'footer footer footer footer' 'left left right right';
+	row-gap: 30px;
 `;
 
 const articleView = css`
@@ -45,6 +46,7 @@ const footer = css`
 	justify-items: center;
 	display: grid;
 	align-items: center;
+	border-top: 1px solid ${palette.neutral[86]};
 `;
 
 const Curation = () => {
@@ -105,6 +107,9 @@ const Curation = () => {
 
 	return (
 		<div css={gridLayout}>
+			<div css={footer}>
+				<Footer articleId={articleId} body={state.body} dispatcher={dispatch} />
+			</div>
 			<div css={articleView}>
 				<GuFrame articlePath={capiId} />
 			</div>
@@ -123,9 +128,6 @@ const Curation = () => {
 						dispatcher={dispatch}
 					/>
 				</form>
-			</div>
-			<div css={footer}>
-				<Footer articleId={articleId} body={state.body} dispatcher={dispatch} />
 			</div>
 		</div>
 	);

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -4,7 +4,7 @@ import { space, palette } from '@guardian/source-foundations';
 import RecipeComponent from '../components/recipe-component';
 import GuFrame from '../components/gu-frame';
 import ImagePicker from '../components/form/form-image-picker';
-import Footer from '../components/footer';
+import Footer, { postRecipe } from '../components/footer';
 
 import { useParams } from 'react-router-dom';
 
@@ -54,9 +54,26 @@ const Curation = () => {
 	const articleId = id ? `/${id}` : '';
 	const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
 	const image = state.body === null ? null : state.body.featuredImage;
+	const scrubbedId = articleId.replace(/^\/+/, '');
+
+	// Console log every 10 seconds
+	useEffect(() => {
+		const interval = setInterval(() => {
+			postRecipe(articleId, state.body)
+				.catch((err) => console.error(err))
+				.then(() =>
+					fetchAndDispatch(
+						`${location.origin}/api/db/${scrubbedId}`,
+						actions.init,
+						'body',
+						dispatch,
+					),
+				);
+		}, 10000);
+		return () => clearInterval(interval);
+	}, [state]);
 
 	useEffect(() => {
-		const scrubbedId = articleId.replace(/^\/+/, '');
 		Promise.all([
 			// Get schema
 			fetchAndDispatch(

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
 import { useState } from 'react';
 import RecipeList from '../components/recipe-list';
 import { listEndpoint } from '../consts/index';
@@ -17,16 +18,35 @@ const Home = (): JSX.Element => {
 		});
 
 	return (
-		<div>
-			<h2>This is it how it works:</h2>
-			<ul>
-				<li>Pick a recipe.</li>
-				<li>Edit it.</li>
-				<li>Save it.</li>
-			</ul>
-			<h3>Why not try one of these?</h3>
+		<div css={mainContainerStyles}>
+			<div css={explainerStyles}>
+				<h2>This is it how it works:</h2>
+				<ul>
+					<li>Pick a recipe.</li>
+					<li>Edit it.</li>
+					<li>Save it.</li>
+				</ul>
+				<div>
+					Read the{' '}
+					<a
+						href="https://docs.google.com/document/d/1wrVUX7vVTLBd0fxqDbQxqmyXoY4Vvyw5aX79tMxROhk/edit#heading=h.7n6l8nswve9p"
+						target="_blank"
+					>
+						recipe data curation guide
+					</a>{' '}
+					for a more in-depth breakdown.
+				</div>
+			</div>
 			{recipeList !== null && <RecipeList list={recipeList} />}
 		</div>
 	);
 };
 export default Home;
+
+const mainContainerStyles = css`
+	padding: 20px;
+`;
+
+const explainerStyles = css`
+	margin-bottom: 30px;
+`;


### PR DESCRIPTION
## What does this change?

This adjusts the /api/list and /api/db/*id endpoints to check both the raw and curated recipe data tables then preferring the curated versions where they exist. There are a few key benefits to this:

- The homepage can now display whether a given recipe has been marked app-ready or not (I've taken the opportunity to make the page as a whole easier on the eye.
- When users go to the curation view they will be met with the edited - and so most up to date - data. Before it would show the raw version regardless
- Curation pages can autosave and refetch data, allowing changes to be reflected in close to real time

## How to test

In the UI I've tested this by toggling the `isAppReady` field, saving the recipe, then seeing the change reflected in the homepage summary view. You can also check the endpoints directly to check that they correlate to the DynamoDB tables contents.

## How can we measure success?

Tool is more pleasant to use and shows the most up-to-date data possible in the curation view. It also starts us down the path of a more customisable homepage. Editorial have already flagged that as the library grows they'll find it useful to filter by fields like author and whether recipes have been curated or not. That's very doable now the API is speaking to both tables.

## Have we considered potential risks?

This is a low risk change. All it changes is reading behaviour - the posting logic is untouched (for now). If anything this makes editing with the tool less risky.

## Images

### Updated homepage view

<img width="1720" alt="image" src="https://github.com/guardian/recipes/assets/11380557/ccec99d6-fadc-45e0-84e9-da46c4b2e52f">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
