### PR TITLE
Rewire schema for serves array

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -279,7 +279,11 @@ class ApiController (
                   "Andrei Lussmann",
                   "Yotam Ottolenghi",
                   "Nigel Slater",
-                  "Jack Monroe"
+                  "Jack Monroe",
+                  "Thomasina Miers",
+                  "Rukmini Iyer",
+                  "Ed Cumming",
+                  "Andrei Lussman"
                 ]
             }
         },
@@ -366,14 +370,31 @@ class ApiController (
                 ],
                 "enum": [
                     null,
+                    "christmas",
+                    "boxing-day",
+                    "new-years-eve",
+                    "thanksgiving",
+                    "veganuary",
                     "burns-night",
-                    "christmas-food-and-drink",
-                    "christmas-food-and-drink-2018",
-                    "christmas-food-and-drink-2019",
-                    "winter-food-and-drink",
-                    "summer-food-and-drink",
-                    "spring-food-and-drink",
-                    "autumn-food-and-drink"
+                    "chinese-new-year",
+                    "valentines-day",
+                    "pancake-day",
+                    "mothers-day",
+                    "holi",
+                    "ramadan",
+                    "easter",
+                    "st-patricks-day",
+                    "eid",
+                    "passover",
+                    "birthday",
+                    "bank-holiday",
+                    "fathers-day",
+                    "halloween",
+                    "diwali",
+                    "bonfire-night",
+                    "hanukkah",
+                    "rosh-hashanah",
+                    "yom-kippur"
                 ]
             }
         },
@@ -384,31 +405,35 @@ class ApiController (
                 "type": ["string", "null"],
                 "enum": [
                     null,
+                    "nordic",
                     "italian",
                     "mexican",
-                    "southern_us",
                     "indian",
                     "french",
                     "chinese",
                     "thai",
-                    "cajun_creole",
                     "japanese",
                     "british",
                     "greek",
                     "spanish",
-                    "middleeastern",
+                    "middle-eastern",
                     "eastern-european",
-                    "north-african/moroccan",
+                    "african",
                     "vietnamese",
                     "korean",
                     "filipino",
                     "irish",
                     "jamaican",
                     "brazilian",
-                    "pan-african",
                     "scandinavian",
                     "australian",
-                    "turkish"
+                    "turkish",
+                    "south-east-asian",
+                    "sri-lankan",
+                    "american",
+                    "south-american",
+                    "caribbean",
+                    "portuguese"
                 ]
             }
         },
@@ -420,15 +445,14 @@ class ApiController (
                   "null"
               ],
               "enum": [
-                  "starter",
-                  "main-course",
-                  "dessert",
-                  "snacks",
                   "breakfast",
-                  "baking",
-                  "barbecue",
-                  "side-dishes",
-                  "soup"
+                  "brunch",
+                  "lunch",
+                  "dinner",
+                  "snack",
+                  "dessert",
+                  "drink",
+                  "starter"
               ]
             }
         },
@@ -439,7 +463,9 @@ class ApiController (
                 "enum": [
                     "vegetarian",
                     "vegan",
-                    "meat"
+                    "pescatarian",
+                    "gluten-free",
+                    "dairy-free"
                 ]
             }
         },
@@ -448,8 +474,7 @@ class ApiController (
             "items": {
                 "type": ["string", "null"],
                 "enum": [
-                    "air fryer",
-                    "blender"
+                    "air-fryer"
                 ]
             }
         },

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -187,35 +187,34 @@ class ApiController (
             "type": ["string", "null"]
         },
         "serves": {
-          "type": "object",
-          "properties": {
-            "amount": {
+          "type": "array",
+          "items": {
               "type": "object",
               "properties": {
-                "min": {
-                  "type": "integer"
+                "amount": {
+                  "type": "object",
+                  "properties": {
+                    "min": {
+                      "type": "integer"
+                    },
+                    "max": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "min",
+                    "max"
+                  ]
                 },
-                "max": {
-                  "type": "integer"
+                "unit": {
+                  "type": "string"
                 }
               },
               "required": [
-                "min",
-                "max"
+                "amount",
+                "unit"
               ]
-            },
-            "unit": {
-              "type": "string",
-                  "enum": [
-                    "people",
-                    "items"
-                  ]
             }
-          },
-          "required": [
-            "amount",
-            "unit"
-          ]
         },
         "featuredImage": {
             "type": ["string", "null"]

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.{Map => MMap}
 
 case class Quantity(absolute: Option[String], from: Option[String], to: Option[String])
 case class Range(min: Double, max: Double)
-case class Ingredient(name: String, amount: Range, unit: String, ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean])
+case class Ingredient(name: String, amount: Range, unit: Option[String], ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean])
 case class IngredientsList(recipeSection: String, ingredientsList: List[Ingredient])
 case class Serves(amount: Range, unit: String)
 case class Instruction(stepNumber: Int, description: String, images: Option[List[String]])
@@ -18,7 +18,7 @@ case class Recipe(
   canonicalArticle: Option[String],
   title: Option[String],
   description: Option[String],
-  serves: Option[Serves],
+  serves: Option[List[Serves]],
   ingredients: List[IngredientsList],
   instructions: List[Instruction],
   cuisineIds: List[String],

--- a/recipes-client/components/form/form-group.tsx
+++ b/recipes-client/components/form/form-group.tsx
@@ -14,6 +14,7 @@ import { Legend } from '@guardian/source-react-components';
 import {
 	isIngredientsField,
 	isInstructionsField,
+	isServesField,
 	isTimingsField,
 } from 'utils/recipe-field-checkers';
 import { renderTimingsFormGroup } from './inputs/timings';
@@ -145,8 +146,8 @@ const getFormFields = (
 			key,
 			dispatcher,
 		);
-	} else if (key === 'serves') {
-		return renderServesFormGroup(formItems, choices, key, dispatcher);
+	} else if (isServesField(formItems)) {
+		return renderServesFormGroup(formItems, schema, choices, key, dispatcher);
 	} else {
 		console.warn(`Cannot get item '${key}' in formItems, leaving field empty.`);
 		console.log(`Form items: ${JSON.stringify(formItems)}`);

--- a/recipes-client/components/form/inputs/serves.tsx
+++ b/recipes-client/components/form/inputs/serves.tsx
@@ -1,16 +1,32 @@
 import { Legend } from '@guardian/source-react-components';
-import { ActionType, Serves } from 'interfaces/main';
+import { ActionType, schemaItem, Serves } from 'interfaces/main';
 import { Dispatch } from 'react';
 import { isRangeField } from 'utils/recipe-field-checkers';
+import { getItemButtons } from '../form-buttons';
+import { getFormFieldsSchema } from '../form-group';
 import FormItem from '../form-item';
 import { renderRangeFormGroup } from './range';
 
 export const renderServesFormGroup = (
 	formItems: Serves,
+	schema: schemaItem,
 	choices: string[] | null,
 	key: string,
 	dispatcher: Dispatch<ActionType>,
 ) => {
+	const formFieldsSchema = getFormFieldsSchema(formItems, schema);
+	const formItemAddId =
+		key.slice(0, -1) + (parseInt(key.slice(-1)) + 1).toString();
+	const formItemRemoveId = key;
+
+	const formItemButtons = getItemButtons(
+		key,
+		formItemAddId,
+		formItemRemoveId,
+		formFieldsSchema,
+		dispatcher,
+	);
+
 	const fields = Object.keys(formItems).map((k: keyof Serves) => {
 		if (isRangeField(formItems[k])) {
 			return renderRangeFormGroup(
@@ -34,6 +50,7 @@ export const renderServesFormGroup = (
 		<fieldset key={`${key}.fieldset`}>
 			<Legend key={`${key}.legend`} text={key}></Legend>
 			{fields}
+			{formItemButtons}
 		</fieldset>,
 	];
 };

--- a/recipes-client/consts/index.ts
+++ b/recipes-client/consts/index.ts
@@ -70,12 +70,12 @@ export const UIschema: UIschemaItem = {
 		'ui:removable': false,
 	},
 	id: {
-		'ui:display': true,
+		'ui:display': false,
 		'ui:locked': true,
 		'ui:removable': false,
 	},
 	canonicalArticle: {
-		'ui:display': true,
+		'ui:display': false,
 		'ui:locked': true,
 		'ui:removable': false,
 	},
@@ -193,12 +193,12 @@ export const UIschema: UIschemaItem = {
 		'ui:removable': true,
 	},
 	techniquesUsedIds: {
-		'ui:display': true,
+		'ui:display': false,
 		'ui:locked': false,
 		'ui:removable': true,
 	},
 	difficultyLevel: {
-		'ui:display': true,
+		'ui:display': false,
 		'ui:locked': false,
 		'ui:removable': true,
 	},

--- a/recipes-client/utils/recipe-field-checkers.tsx
+++ b/recipes-client/utils/recipe-field-checkers.tsx
@@ -7,6 +7,7 @@ import {
 	isSchemaType,
 	schemaItem,
 	schemaType,
+	Serves,
 	Timing,
 } from 'interfaces/main';
 
@@ -14,7 +15,7 @@ export const isTimingsField = (
 	obj: Timing | Record<string, unknown>,
 ): obj is Timing => {
 	if (typeof obj !== 'object' || obj === null) return false;
-	return Object.keys(obj).includes('qualifier');
+	return Object.keys(obj).includes('durationInMins');
 };
 
 export const isIngredientsField = (
@@ -45,6 +46,13 @@ export const isInstructionsField = (
 	if (obj === undefined || obj === null) return false;
 	if (isSchemaType(obj) || isAllRecipeFields(obj)) return false;
 	return Object.keys(obj).includes('stepNumber');
+};
+
+export const isServesField = (obj: Serves): obj is Serves => {
+	if (typeof obj !== 'object' || obj === null) return false;
+	return (
+		Object.keys(obj).includes('amount') && Object.keys(obj).includes('unit')
+	);
 };
 
 export const isRangeField = (


### PR DESCRIPTION
This adjusts the schema to expect an array of serves objects rather than just one. The UI generation has been changed to reflect this and I've taken the opportunity to update the dropdown options and hide noisy/unnecessary/contentious fields ahead of editorial having a crack at some curation next week.