### PR TITLE
Add data summary view to curation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@guardian/source-foundations": "^13.0.0",
         "@guardian/source-react-components": "^16.0.0",
+        "@guardian/source-react-components-development-kitchen": "^14.0.2",
         "@reduxjs/toolkit": "^1.9.5",
         "@swc/helpers": "^0.5.2",
         "@types/lodash-es": "^4.17.9",
@@ -1772,7 +1773,6 @@
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-15.8.0.tgz",
       "integrity": "sha512-MqTzCuG2j2xBqwihEMmHmEl8o1Mr7iyYEzpd+soQcw0XdhWh0Oye43+rYXo74t7S0FAtxN7Omm8lkVsXP+vOAA==",
-      "dev": true,
       "peer": true,
       "peerDependencies": {
         "tslib": "^2.5.3",
@@ -1812,12 +1812,31 @@
       }
     },
     "node_modules/@guardian/source-react-components": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/source-react-components/-/source-react-components-16.0.0.tgz",
-      "integrity": "sha512-oSRa1TjRvbnfYIEa+qMz23aCM6V73pIvP2ca64dP9dNopNR1PgooNlf7PihjXDEkyBo4ks9udMRzzAd3nfst6A==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/source-react-components/-/source-react-components-16.0.1.tgz",
+      "integrity": "sha512-M/zrs+G5NqykicECNf803B9815tVkPfazwmYsGfrDdKGptBmLhcofGlpC/MGdKiJ9lTlOQBieUyZ2y6i2mBJyQ==",
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@guardian/source-foundations": "^13.0.0",
+        "react": "^18.2.0",
+        "tslib": "^2.5.3",
+        "typescript": "~5.1.3"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@guardian/source-react-components-development-kitchen": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-14.0.2.tgz",
+      "integrity": "sha512-F5nDwRuekC9ZUSEy+FdXMnke/q/rYi4Mple2t1rv6d61oHsOnnGxReQtfPYyVnYv5zGYo8phlOtLGstSQg3DRQ==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@guardian/libs": "^15.4.0",
+        "@guardian/source-foundations": "^13.0.0",
+        "@guardian/source-react-components": "^16.0.1",
         "react": "^18.2.0",
         "tslib": "^2.5.3",
         "typescript": "~5.1.3"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@emotion/react": "^11.11.1",
     "@guardian/source-foundations": "^13.0.0",
     "@guardian/source-react-components": "^16.0.0",
+    "@guardian/source-react-components-development-kitchen": "^14.0.2",
     "@reduxjs/toolkit": "^1.9.5",
     "@swc/helpers": "^0.5.2",
     "@types/lodash-es": "^4.17.9",

--- a/recipes-client/components/app-ready-status.tsx
+++ b/recipes-client/components/app-ready-status.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
+import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+
+export const AppReadyStatus = ({ isAppReady }: { isAppReady: boolean }) => {
+	{
+		return isAppReady ? (
+			<span css={tickStyles}>
+				<SvgTickRound isAnnouncedByScreenReader size="medium" />
+			</span>
+		) : (
+			<span css={crossStyles}>
+				<SvgCrossRound isAnnouncedByScreenReader size="medium" />
+			</span>
+		);
+	}
+};
+
+const tickStyles = css`
+	svg {
+		fill: ${palette.success[500]};
+	}
+`;
+
+const crossStyles = css`
+	svg {
+		fill: ${palette.error[500]};
+	}
+`;

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -112,7 +112,6 @@ const PictureGrid = (props: {
 							}
 							css={{
 								gridArea: `${Math.floor(i / 5 + 1)}`,
-								background: 'lightgrey',
 								justifyItems: 'center',
 								display: 'grid',
 								align: 'center',

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -1,0 +1,183 @@
+/** @jsxImportSource @emotion/react */
+import { allRecipeFields, Ingredient } from 'interfaces/main';
+import { css } from '@emotion/react';
+import { AppReadyStatus } from '../app-ready-status';
+import { Range } from 'interfaces/main';
+import { palette } from '@guardian/source-foundations';
+
+interface DataPreviewProps {
+	recipeData: allRecipeFields | null;
+}
+
+const prettifyRange = (amount: Range) => {
+	return amount.min === amount.max ? amount.min : `${amount.min}-${amount.max}`;
+};
+
+const prettifyDurationInMins = (durationInMins: number): string => {
+	const hours = Math.floor(durationInMins / 60);
+	const mins = durationInMins % 60;
+	return `${hours > 0 ? `${hours}h` : ''} ${mins > 0 ? `${mins}m` : ''}`;
+};
+
+export const DataPreview = ({ recipeData }: DataPreviewProps) => {
+	const renderIngredientAsSentence = ({
+		name,
+		amount,
+		unit,
+		prefix,
+		suffix,
+	}: Ingredient) => {
+		return `${prettifyRange(amount)} ${unit ? unit : ''} ${
+			prefix ? prefix : ''
+		} ${name} ${suffix ? suffix : ''}`;
+	};
+
+	return recipeData === null ? (
+		<div>Recipe data could not be loaded.</div>
+	) : (
+		<div css={previewStyles}>
+			<div>
+				<small>Marked app-ready</small>
+				<div>
+					<AppReadyStatus isAppReady={recipeData.isAppReady} />
+				</div>
+			</div>
+			<div>
+				<small>Title</small>
+				<div>{recipeData.title}</div>
+			</div>
+			<div>
+				<small>Description</small>
+				<div>
+					{recipeData.description.length > 0 ? recipeData.description : '-'}
+				</div>
+			</div>
+			<div>
+				<small>Contributor(s)</small>
+				<div>
+					{recipeData.contributors.length > 0
+						? recipeData.contributors.join(', ')
+						: '-'}
+				</div>
+			</div>
+			<div>
+				<small>Byline(s)</small>
+				<div>
+					{recipeData.byline.length > 0 ? recipeData.byline.join(', ') : '-'}
+				</div>
+			</div>
+			<div>
+				<small>Serves</small>
+				<ul>
+					{recipeData.serves?.map((serves, i) => {
+						return (
+							<li key={i}>
+								{prettifyRange(serves.amount)} {serves.unit}
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+			<div>
+				<small>Timings</small>
+				<ul>
+					{recipeData.timings.map((timing, i) => {
+						return (
+							<li key={i}>
+								<strong>{timing.qualifier}</strong>:{' '}
+								{prettifyDurationInMins(timing.durationInMins)}
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+			<div>
+				<small>Method</small>
+				<ul>
+					{recipeData.instructions.map((instruction, i) => {
+						return (
+							<li>
+								<strong>{instruction.stepNumber}.</strong>{' '}
+								{instruction.description}
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+			<div>
+				<small>Ingredients</small>
+				<ul>
+					{recipeData.ingredients.map((ingredient, i) => {
+						return (
+							<>
+								<li key={i}>{ingredient.recipeSection}</li>
+								<ul>
+									{ingredient.ingredientsList.map((ingredient, i) => {
+										return (
+											<li key={i}>{renderIngredientAsSentence(ingredient)}</li>
+										);
+									})}
+								</ul>
+							</>
+						);
+					})}
+				</ul>
+			</div>
+			<div>
+				<small>Cuisines</small>
+				{recipeData.cuisineIds.length === 0 ? (
+					<div>-</div>
+				) : (
+					<ul>
+						{recipeData.cuisineIds.map((cuisine, i) => {
+							return <li key={i}>{cuisine}</li>;
+						})}
+					</ul>
+				)}
+			</div>
+			<div>
+				<small>Meal types</small>
+				{recipeData.mealTypeIds.length === 0 ? (
+					<div>-</div>
+				) : (
+					<ul>
+						{recipeData.mealTypeIds.map((mealType, i) => {
+							return <li key={i}>{mealType}</li>;
+						})}
+					</ul>
+				)}
+			</div>
+			<div>
+				<small>Celebrations</small>
+				{recipeData.celebrationIds.length === 0 ? (
+					<div>-</div>
+				) : (
+					<ul>
+						{recipeData.celebrationIds.map((celebration, i) => {
+							return <li key={i}>{celebration}</li>;
+						})}
+					</ul>
+				)}
+			</div>
+		</div>
+	);
+};
+
+const previewStyles = css`
+	h3 {
+		margin-top: 0;
+	}
+	small {
+		background-color: ${palette.neutral[86]};
+		padding: 0.25rem;
+		border-radius: 0.25rem;
+		display: inline-block;
+		margin-bottom: 0.25rem;
+	}
+	li {
+		margin-bottom: 0.5rem;
+	}
+	div {
+		margin-bottom: 1rem;
+	}
+`;

--- a/recipes-client/components/recipe-component.tsx
+++ b/recipes-client/components/recipe-component.tsx
@@ -18,10 +18,12 @@ interface RecipeComponentProps {
 	dispatcher: Dispatch<ActionType>;
 }
 
-const RecipeComponent = (
-	props: RecipeComponentProps,
-): JSX.Element | JSX.Element[] => {
-	const { body, isLoading, schema, dispatcher } = props;
+const RecipeComponent = ({
+	body,
+	schema,
+	isLoading,
+	dispatcher,
+}: RecipeComponentProps): JSX.Element | JSX.Element[] => {
 	const UIOrder = isUIschemaItem(UIschema) ? UIschema['ui:order'] : null;
 
 	if (isLoading) {

--- a/recipes-client/components/recipe-list.tsx
+++ b/recipes-client/components/recipe-list.tsx
@@ -7,6 +7,7 @@ import {
 	SvgExternal,
 } from '@guardian/source-react-components';
 import { curationEndpoint } from '../consts/index';
+import { AppReadyStatus } from './app-ready-status';
 
 interface RecipeListProps {
 	list: RecipeListType[];
@@ -47,15 +48,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 								</td>
 								<td key={`path_${i}_author`}> {contributors.join(', ')} </td>
 								<td key={`path_${i}_app`}>
-									{isAppReady ? (
-										<span css={tickStyles}>
-											<SvgTickRound isAnnouncedByScreenReader size="small" />
-										</span>
-									) : (
-										<span css={crossStyles}>
-											<SvgCrossRound isAnnouncedByScreenReader size="small" />
-										</span>
-									)}
+									<AppReadyStatus isAppReady={isAppReady} />
 								</td>
 								<td key={`path_${i}_links`}>
 									<a
@@ -92,18 +85,6 @@ const tableStyles = css`
 	th {
 		font-weight: bold;
 		background-color: #eee;
-	}
-`;
-
-const tickStyles = css`
-	svg {
-		fill: ${palette.success[500]};
-	}
-`;
-
-const crossStyles = css`
-	svg {
-		fill: ${palette.error[500]};
 	}
 `;
 

--- a/recipes-client/consts/index.ts
+++ b/recipes-client/consts/index.ts
@@ -188,7 +188,7 @@ export const UIschema: UIschemaItem = {
 		'ui:removable': true,
 	},
 	utensilsAndApplianceIds: {
-		'ui:display': true,
+		'ui:display': false,
 		'ui:locked': false,
 		'ui:removable': true,
 	},

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -52,6 +52,7 @@ export const isAllRecipeFields = (
 };
 
 export interface recipeFields {
+	isAppReady: boolean;
 	id: string; // Unique identifier
 	canonicalArticle: string; // ID of recipe in Content API
 	title: string; // Name of the recipe
@@ -63,11 +64,11 @@ export interface recipeFields {
 	suitableForDietIds: string[]; // List of diets recipe is suitable for (e.g. vegetarian, vegan, kosher, halal, etc.)
 	cuisineIds: string[]; // Cuisine type(s) of recipe (e.g. Italian, Mexican, etc.)
 	mealTypeIds: string[]; // Categories of recipe (e.g. breakfast, lunch, dinner, dessert)
-	celebrationsIds: string[]; // Celebration(s) associated with recipe (e.g. Christmas, Thanksgiving, etc.)
+	celebrationIds: string[]; // Celebration(s) associated with recipe (e.g. Christmas, Thanksgiving, etc.)
 	utensilsAndApplianceIds: string[]; // List of equipment needed for recipe (e.g. hob, frying pan, air fryer)
 	techniquesUsedIds: string[]; // List of cooking techniques used (e.g. deep frying, baking)
 	difficultyLevel: DifficultyLevel;
-	serves?: Serves; // Number of servings
+	serves?: Serves[]; // Number of servings
 	timings: Timing[];
 	instructions: Instruction[]; // Steps breaking down the recipe. For recipes that can't be stepified this would just be one big 'step' containing the method
 }
@@ -87,7 +88,7 @@ export type recipeItem =
 	| Timing[]
 	| Ingredient[];
 
-interface Range {
+export interface Range {
 	min: number; // Minimum value
 	max: number; // Maximum value
 }

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -11,43 +11,11 @@ import { useParams } from 'react-router-dom';
 import { recipeReducer, defaultState } from '../reducers/recipe-reducer';
 import { actions } from '../actions/recipeActions';
 import { apiURL, capiProxy, schemaEndpoint } from '../consts/index';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useImmerReducer } from 'use-immer';
 import { fetchAndDispatch, setLoadingFinished } from '../utils/requests';
-
-// Styles
-
-const gridLayout = css`
-	display: grid;
-	grid-template-columns: 25% 25% 25% 25%;
-	height: 100vh;
-	grid-template-rows: 50px 1fr;
-	grid-template-areas: 'footer footer footer footer' 'left left right right';
-	row-gap: 30px;
-`;
-
-const articleView = css`
-	grid-area: left;
-	background: ${palette.neutral[100]};
-	overflow: auto;
-	padding: 0 ${space[5]}px;
-`;
-
-const dataView = css`
-	grid-area: right;
-	background: lightgray;
-	overflow: auto;
-	padding: 5px;
-`;
-
-const footer = css`
-	grid-area: footer;
-	background: ${palette.brand[400]};
-	justify-items: center;
-	display: grid;
-	align-items: center;
-	border-top: 1px solid ${palette.neutral[86]};
-`;
+import { Tabs } from '@guardian/source-react-components-development-kitchen';
+import { DataPreview } from 'components/preview/data-preview';
 
 const Curation = () => {
 	const { section: id } = useParams();
@@ -58,7 +26,8 @@ const Curation = () => {
 	const image = state.body === null ? null : state.body.featuredImage;
 	const scrubbedId = articleId.replace(/^\/+/, '');
 
-	// Console log every 10 seconds
+	const [selectedTab, setSelectedTab] = useState('summary');
+
 	useEffect(() => {
 		const interval = setInterval(() => {
 			postRecipe(articleId, state.body)
@@ -105,6 +74,36 @@ const Curation = () => {
 			});
 	}, [articleId, dispatch]);
 
+	const tabsContent = [
+		{
+			id: 'summary',
+			text: 'Summary',
+			content: <DataPreview recipeData={state.body} />,
+		},
+		{
+			id: 'edit',
+			text: 'Edit',
+			content: (
+				<>
+					<ImagePicker
+						html={state.html}
+						selected={image}
+						isLoading={state.isLoading}
+						dispatcher={dispatch}
+					/>
+					<form>
+						<RecipeComponent
+							isLoading={state.isLoading}
+							body={state.body}
+							schema={state.schema}
+							dispatcher={dispatch}
+						/>
+					</form>
+				</>
+			),
+		},
+	];
+
 	return (
 		<div css={gridLayout}>
 			<div css={footer}>
@@ -114,23 +113,51 @@ const Curation = () => {
 				<GuFrame articlePath={capiId} />
 			</div>
 			<div css={dataView}>
-				<ImagePicker
-					html={state.html}
-					selected={image}
-					isLoading={state.isLoading}
-					dispatcher={dispatch}
-				/>
-				<form>
-					<RecipeComponent
-						isLoading={state.isLoading}
-						body={state.body}
-						schema={state.schema}
-						dispatcher={dispatch}
-					/>
-				</form>
+				<Tabs
+					tabsLabel="Toggle between form and preview"
+					tabElement="button"
+					tabs={tabsContent}
+					selectedTab={selectedTab}
+					onTabChange={(tabId: string): void => {
+						setSelectedTab(tabId);
+					}}
+				></Tabs>
 			</div>
 		</div>
 	);
 };
 
 export default Curation;
+
+// Styles
+
+const gridLayout = css`
+	display: grid;
+	grid-template-columns: 25% 25% 25% 25%;
+	height: 100vh;
+	grid-template-rows: 50px 1fr;
+	grid-template-areas: 'footer footer footer footer' 'left left right right';
+	row-gap: 30px;
+`;
+
+const articleView = css`
+	grid-area: left;
+	background: ${palette.neutral[100]};
+	overflow: auto;
+	padding: 0 ${space[5]}px;
+`;
+
+const dataView = css`
+	grid-area: right;
+	overflow: auto;
+	padding: 5px;
+`;
+
+const footer = css`
+	grid-area: footer;
+	background: ${palette.brand[400]};
+	justify-items: center;
+	display: grid;
+	align-items: center;
+	border-top: 1px solid ${palette.neutral[86]};
+`;


### PR DESCRIPTION
## What does this change?

As requested by Anna B, this adds a option to view a plaintext summary of recipe data on curation pages. Now when users select a recipe to edit they will be met with the summary on the right rather than the form. To get to the form they select the 'Edit' tab.

![image](https://github.com/guardian/recipes/assets/11380557/b0182348-3edc-401e-b046-3dfbf25934d6)

This takes advantage of the `Tabs` component from [`source-react-components-development-kitchen `](https://github.com/guardian/csnx/tree/main/libs/%40guardian/source-react-components-development-kitchen) courtesy of @guardian/client-side-infra, which I think makes for a pretty smooth UI.

No doubt there is room for further improvement here but it's a feature is was keen to get live. It should make it much easier for editorial to scan recipe data and spot missing/iffy fields.

