### PR TITLE
cache assets effectively: add hashes to assets (notably `index.js`)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,5 +67,6 @@ lazy val root = (project in file("."))
     Universal / javaOptions ++= Seq(
       // Remove the PID file
       "-Dpidfile.path=/dev/null"
-    )
+    ),
+    Assets / pipelineStages := Seq(digest)
 ))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,8 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
Assets didn't have hashes and so were cached, which meant users wouldn't get the latest changes promptly.

Some of the steps from
https://www.playframework.com/documentation/2.4.x/Assets#Reverse-routing-and-fingerprinting-for-public-assets were already done (from long ago) but needed to add the `sbt-digest` plugin then reference in the `pipelineStages` in the `build.sbt`.