### PR TITLE
Set up PRout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '8'
+      - name: Write the current GIT hash to public/prout.html
+        run: git rev-parse HEAD > public/prout.html
       - run: ./scripts/ci-sbt
       - name: Rename files for easy finding by guardian/actions-riff-raff
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ logs
 .bsp
 .idea
 recipes.conf
+/public/prout.html

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-
 libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/public/.prout.json
+++ b/public/.prout.json
@@ -1,0 +1,8 @@
+{
+  "checkpoints": {
+    "PROD": {
+      "url": "https://recipes.gutools.co.uk/assets/prout.html",
+      "overdue": "10M"
+    }
+  }
+}


### PR DESCRIPTION
Add [PRout](https://github.com/guardian/prout) configuration. We opted for a simple static file generated at CI time rather than using SBTBuildInfo. We've removed the dependency accordingly as it wasn't being used.