### PR TITLE
Add original text fields to schema

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -208,6 +208,9 @@ class ApiController (
                 },
                 "unit": {
                   "type": "string"
+                },
+                "text": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -340,12 +343,13 @@ class ApiController (
                           },
                           "optional": {
                             "type": "boolean"
+                          },
+                          "text": {
+                            "type": "string"
                           }
                         },
                         "required": [
-                          "name",
-                          "amount",
-                          "unit"
+                          "name"
                         ]
                       }
 

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -6,9 +6,9 @@ import scala.collection.immutable.{Map => MMap}
 
 case class Quantity(absolute: Option[String], from: Option[String], to: Option[String])
 case class Range(min: Double, max: Double)
-case class Ingredient(name: String, amount: Range, unit: Option[String], ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean])
+case class Ingredient(name: String, amount: Option[Range], unit: Option[String], ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean], text: Option[String])
 case class IngredientsList(recipeSection: String, ingredientsList: List[Ingredient])
-case class Serves(amount: Range, unit: String)
+case class Serves(amount: Range, unit: String, text: Option[String])
 case class Instruction(stepNumber: Int, description: String, images: Option[List[String]])
 case class Timing(qualifier: String, durationInMins: Int)
 

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -106,6 +106,7 @@ export interface Ingredient {
 	prefix?: string; // Type of
 	suffix?: string; // Any pre-cooking preparation needed (e.g. finely chopped, drained)
 	optional: boolean; // Whether ingredient is optional
+	text?: string; // Original text
 }
 
 export type Timing = {
@@ -116,6 +117,7 @@ export type Timing = {
 export interface Serves {
 	amount: Range; // Number of servings
 	unit: string; // Unit of measurement, 'people' of 'units'
+	text?: string; // Original text
 }
 
 export type BylineEntry =

--- a/recipes-client/interfaces/nastyHardcodedSchemas.tsx
+++ b/recipes-client/interfaces/nastyHardcodedSchemas.tsx
@@ -25,6 +25,9 @@ export const ingredientSchema = {
 	optional: {
 		type: 'boolean',
 	},
+	text: {
+		type: 'string',
+	},
 };
 
 export const ingredientGroupSchema = {
@@ -34,6 +37,6 @@ export const ingredientGroupSchema = {
 	ingredientsList: {
 		type: 'array',
 		items: ingredientSchema,
-		required: ['name', 'amount', 'unit'],
+		required: ['name'],
 	},
 };


### PR DESCRIPTION
Update the schema to reflect changes agreed on by Basecamp, D&I, CoPip, and Editorial. Ingredient and Serves objects now include the original text