### PR TITLE
Ingredient preview adjustments

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -286,7 +286,8 @@ class ApiController (
                   "Thomasina Miers",
                   "Rukmini Iyer",
                   "Ed Cumming",
-                  "Andrei Lussman"
+                  "Andrei Lussman",
+                  "Anna Jones"
                 ]
             }
         },

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -27,9 +27,10 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 		prefix,
 		suffix,
 	}: Ingredient) => {
-		return `${prettifyRange(amount)} ${unit ? unit : ''} ${
-			prefix ? prefix : ''
-		} ${name} ${suffix ? suffix : ''}`;
+		const concernsTins = unit?.includes('tin');
+		return `${prettifyRange(amount)}${concernsTins ? ' x ' : ''}${
+			unit ? unit : ''
+		} ${prefix ? prefix : ''} ${name} ${suffix ? suffix : ''}`;
 	};
 
 	return recipeData === null ? (


### PR DESCRIPTION
This tweaks the presentation of ingredients in preview mode based on feedback from Anna B.

Now:

- An 'x' is inserted between the amount and the unit when the unit involves tins
- No space between amount and unit

### Before

![image](https://github.com/guardian/recipes/assets/11380557/793c9cae-b241-42b9-a645-2de02776fb62)

### After

![image](https://github.com/guardian/recipes/assets/11380557/d56c3416-2905-456a-9033-fb03ef5931af)

I've also added Anna Jones to the list of contributor options ahead of some rhubarb recipes dropping into the raw database.