### PR TITLE
Filter displayed recipes on dashboard

### DIFF
--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -1,19 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { palette } from '@guardian/source-foundations';
-import {
-	SvgCrossRound,
-	SvgTickRound,
-	SvgExternal,
-} from '@guardian/source-react-components';
-import { curationEndpoint } from '../consts/index';
-import { AppReadyStatus } from './app-ready-status';
+import { SvgExternal } from '@guardian/source-react-components';
+import { curationEndpoint } from '../../consts/index';
+import { AppReadyStatus } from '../app-ready-status';
 
 interface RecipeListProps {
 	list: RecipeListType[];
 }
 
-interface RecipeListType {
+export interface RecipeListType {
 	id: string;
 	title: string;
 	contributors: string[];
@@ -24,6 +19,12 @@ interface RecipeListType {
 const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 	return (
 		<table css={tableStyles}>
+			<colgroup>
+				<col style={{ width: '60%' }} />
+				<col style={{ width: '20%' }} />
+				<col style={{ width: '10%' }} />
+				<col style={{ width: '10%' }} />
+			</colgroup>
 			<thead>
 				<tr>
 					<th>Recipe</th>

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -1,11 +1,38 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { useState } from 'react';
-import RecipeList from '../components/recipe-list';
+import { palette } from '@guardian/source-foundations';
+import { Radio, RadioGroup } from '@guardian/source-react-components';
+import { useEffect, useState } from 'react';
+import RecipeList, {
+	RecipeListType,
+} from '../components/dashboard/recipe-list';
 import { listEndpoint } from '../consts/index';
 
 const Home = (): JSX.Element => {
-	const [recipeList, setList] = useState(null);
+	const [recipeList, setList] = useState<RecipeListType[]>([]);
+	const [displayedRecipes, setDisplayedRecipes] = useState<RecipeListType[]>(
+		[],
+	);
+	const [listFilter, setListFilter] = useState<
+		'all' | 'curated' | 'non-curated'
+	>('all');
+
+	useEffect(() => {
+		const recipes = recipeList.filter((recipe) => {
+			if (listFilter === 'all') {
+				return true;
+			} else if (listFilter === 'curated') {
+				return recipe.isAppReady;
+			} else if (listFilter === 'non-curated') {
+				return !recipe.isAppReady;
+			} else {
+				console.error('Invalid filter');
+				return true;
+			}
+		});
+		setDisplayedRecipes(recipes);
+	}, [recipeList, listFilter]);
+
 	fetch(listEndpoint)
 		.then((response) => {
 			return response.json();
@@ -17,8 +44,28 @@ const Home = (): JSX.Element => {
 			return null;
 		});
 
+	const counterStyles = css`
+		position: fixed;
+		top: 0;
+		right: 0;
+		background-color: ${palette.brandAlt[300]};
+		padding: 10px;
+		font-size: 1.2rem;
+		font-weight: bold;
+		color: #121212;
+		border-bottom-left-radius: 5px;
+		z-index: 1;
+	`;
+
 	return (
 		<div css={mainContainerStyles}>
+			{/* Have mustard colour div fixed in the top right corner saying how many app-ready recipes there are */}
+			<div css={counterStyles}>
+				<div>
+					<span>{recipeList.filter((recipe) => recipe.isAppReady).length}</span>{' '}
+					app-approved recipes and counting
+				</div>
+			</div>
 			<div css={explainerStyles}>
 				<h2>This is it how it works:</h2>
 				<ul>
@@ -37,7 +84,37 @@ const Home = (): JSX.Element => {
 					for a more in-depth breakdown.
 				</div>
 			</div>
-			{recipeList !== null && <RecipeList list={recipeList} />}
+			<hr />
+			<div>
+				<RadioGroup orientation="horizontal" label="Filter displayed recipes">
+					<Radio
+						name="filter"
+						value="all"
+						label="All"
+						onClick={() => setListFilter('all')}
+						checked={listFilter === 'all'}
+					/>
+					<Radio
+						name="filter"
+						value="curated"
+						label="Curated"
+						onClick={() => setListFilter('curated')}
+						checked={listFilter === 'curated'}
+					/>
+					<Radio
+						name="filter"
+						value="non-curated"
+						label="Awaiting curation"
+						onClick={() => setListFilter('non-curated')}
+						checked={listFilter === 'non-curated'}
+					/>
+				</RadioGroup>
+			</div>
+			{recipeList.length > 0 && (
+				<div>
+					<RecipeList list={displayedRecipes} />
+				</div>
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
With recipe data starting to flow into Hatch it felt like time to give users control over the homepage. This PR adds filters for all, curated, and non-curated recipes:

![image](https://github.com/guardian/recipes/assets/11380557/88b3874b-13f1-47f4-a059-86bdcd780e06)

I've also chucked in an app-ready counter in the top right hand corner as that seemed like a nice thing to give visibility.