### PR TITLE
Add `composerId` and `webPublicationDate` to model

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -318,7 +318,7 @@ class ApiController (
                 "type": "object",
                 "properties": {
                   "recipeSection": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "ingredientsList": {
                     "type": "array",
@@ -371,7 +371,6 @@ class ApiController (
                   }
                 },
                 "required": [
-                  "recipeSection",
                   "ingredientsList"
                 ]
               }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -180,6 +180,12 @@ class ApiController (
         "canonicalArticle": {
             "type": ["string", "null"]
         },
+        "composerId": {
+            "type": ["string", "null"]
+        },
+        "webPublicationDate": {
+            "type": ["string", "null"]
+        },
         "title": {
             "type": ["string", "null"]
         },
@@ -237,6 +243,9 @@ class ApiController (
                 },
                 "durationInMins": {
                   "type": "integer"
+                },
+                "text": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -288,7 +297,11 @@ class ApiController (
                   "Ed Cumming",
                   "Andrei Lussman",
                   "Anna Jones",
-                  "Rachel Roddy"
+                  "Rachel Roddy",
+                  "Sally Clarke",
+                  "Nigella Lawson",
+                  "Giuseppe Dell’Anno",
+                  "Katie Cross"
                 ]
             }
         },

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -30,6 +30,7 @@ case class Recipe(
   celebrationIds: List[String],
   mealTypeIds: List[String],
   utensilsAndApplianceIds: List[String],
+  suitableForDietIds: List[String],
   techniquesUsedIds: List[String],
   difficultyLevel: Option[String],
 )

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -10,11 +10,13 @@ case class Ingredient(name: String, amount: Option[Range], unit: Option[String],
 case class IngredientsList(recipeSection: String, ingredientsList: List[Ingredient])
 case class Serves(amount: Range, unit: String, text: Option[String])
 case class Instruction(stepNumber: Int, description: String, images: Option[List[String]])
-case class Timing(qualifier: String, durationInMins: Int)
+case class Timing(qualifier: String, durationInMins: Int, text: Option[String])
 
 case class Recipe(
   isAppReady: Boolean,
   id: String,
+  composerId: Option[String],
+  webPublicationDate: Option[String],
   canonicalArticle: Option[String],
   title: Option[String],
   description: Option[String],

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -128,6 +128,18 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 				</ul>
 			</div>
 			<div>
+				<small>Diets</small>
+				{recipeData.suitableForDietIds.length === 0 ? (
+					<div>-</div>
+				) : (
+					<ul>
+						{recipeData.suitableForDietIds.map((diet, i) => {
+							return <li key={i}>{diet}</li>;
+						})}
+					</ul>
+				)}
+			</div>
+			<div>
 				<small>Cuisines</small>
 				{recipeData.cuisineIds.length === 0 ? (
 					<div>-</div>

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -53,8 +53,10 @@ export const isAllRecipeFields = (
 
 export interface recipeFields {
 	isAppReady: boolean;
+	composerId: string; // Unique identifier of canonical article in Composer
 	id: string; // Unique identifier
 	canonicalArticle: string; // ID of recipe in Content API
+	webPublicationDate: string; // Date recipe was published
 	title: string; // Name of the recipe
 	description: string; // Short description of the recipe
 	featuredImage: string; // !! Actually capiImage


### PR DESCRIPTION
Also restore displaying cuisines in preview (see https://github.com/guardian/recipes/pull/60) and adds `text` field to servings. I also realised `suitableForDietIds` wasn't in the backend model and so wasn't making it into the curated database. This has been fixed.


