### PR TITLE
Bump up instance size from `SMALL` to `MEDIUM`

### DIFF
--- a/cdk/lib/__snapshots__/recipes.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes.test.ts.snap
@@ -895,7 +895,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           "ImageId": {
             "Ref": "AMIRecipes",
           },
-          "InstanceType": "t3.small",
+          "InstanceType": "t3.medium",
           "MetadataOptions": {
             "HttpTokens": "required",
           },

--- a/cdk/lib/recipes.ts
+++ b/cdk/lib/recipes.ts
@@ -18,7 +18,7 @@ export class Recipes extends GuStack {
     const ec2App = new GuEc2App(this, {
       applicationPort: 9000,
       app: appName,
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM),
       access: { scope: AccessScope.PUBLIC },
       userData: [
         '#!/bin/bash -ev',


### PR DESCRIPTION
We're having an issue where visitors to Hatch occasionally get 502 errors. One potential reason for this is the instance size being too small. Given the current one is a SMALL T3 this seemed like a sensible thing to try.

Will also be turning on CloudWatch agent as suggested by @akash1810.