### PR TITLE
Pinboard 📌

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -5,6 +5,7 @@ import com.gu.pandomainauth.PublicSettings
 import config.Config
 import play.api.Logging
 import play.api.mvc._
+import model.Stage.Prod
 
 /**
  * This controller creates an `Action` to handle HTTP requests to the
@@ -25,6 +26,12 @@ class HomeController (
   def index(id: String) = ApiAuthAction {
     logger.info(s"Hello there, using api key: ${config.capiApiKey.slice(0,5)}...")
 
-    Ok(views.html.index())
+    val pinboardDomain = if (config.stage == Prod) {
+      "gutools.co.uk"
+    } else {
+      "code.dev-gutools.co.uk" // This assumes we're not developing Pinboard in parrallel
+    }
+
+    Ok(views.html.index(pinboardDomain))
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,3 +1,5 @@
+@(pinboardDomain: String)
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -14,5 +16,6 @@
   <body>
     <div id="root"></div>
     <script src="@routes.Assets.versioned("recipes-client/index.js")" type="text/javascript"></script>
+    <script async src="https://pinboard.@pinboardDomain/pinboard.loader.js" type="text/javascript"></script>
   </body>
 </html>

--- a/recipes-client/components/curation/pinboard-track-and-preselect.tsx
+++ b/recipes-client/components/curation/pinboard-track-and-preselect.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect, useState } from 'react';
+
+interface PinboardTrackAndPreselectProps {
+	maybeComposerId: string | undefined;
+	maybeTitle: string | undefined;
+}
+
+export const PinboardTrackAndPreselect = ({
+	maybeComposerId,
+	maybeTitle,
+}: PinboardTrackAndPreselectProps) => {
+	const [maybeWorkflowId, setMaybeWorkflowId] = useState<string>();
+
+	useEffect(() => {
+		(async () => {
+			if (!maybeComposerId) return;
+			const workflowDomain = window.location.host
+				.replace('recipes', 'workflow')
+				.replace('.local.', '.code.');
+			const workflowContentUrl = `https://${workflowDomain}/api/content`;
+			const workflowLookupResponse = await fetch(
+				`${workflowContentUrl}/${maybeComposerId}`,
+				{
+					credentials: 'include',
+				},
+			);
+			if (workflowLookupResponse.ok) {
+				return setMaybeWorkflowId(
+					(await workflowLookupResponse.json()).data.id,
+				);
+			} else if (workflowLookupResponse.status === 419) {
+				console.error(
+					"Not logged in to Workflow, Pinboard won't be pre-selected",
+				);
+			} else if (workflowLookupResponse.status === 404) {
+				const trackInWorkflowResponse = await fetch(workflowContentUrl, {
+					method: 'POST',
+					credentials: 'include',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						composerId: maybeComposerId,
+						title:
+							window.prompt(
+								'Please enter the working title for workflow?',
+								maybeTitle,
+							) || maybeTitle,
+						status: 'Writers', //TODO is Subs a more sensible starting status
+						section: { name: 'Recipes Data' },
+						contentType: 'article', // TODO is this one actually needed
+						prodOffice: 'UK', //TODO is everything going to be UK based??
+					}),
+				});
+				if (trackInWorkflowResponse.ok) {
+					return setMaybeWorkflowId(
+						(await trackInWorkflowResponse.json()).data.stubId,
+					);
+				}
+			}
+			console.error(
+				"Failed looking up in workflow, pinboard won't be pre-selected",
+				workflowLookupResponse,
+			);
+		})();
+	}, [maybeComposerId]);
+
+	return maybeWorkflowId ? (
+		// @ts-ignore -- this element is not valid JSX but IS meaningful/detected by Pinboard
+		<pinboard-preselect data-composer-id={maybeComposerId}></pinboard-preselect>
+	) : null;
+};

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -18,6 +18,7 @@ import { useImmerReducer } from 'use-immer';
 import { fetchAndDispatch, setLoadingFinished } from '../utils/requests';
 import { Tabs } from '@guardian/source-react-components-development-kitchen';
 import { DataPreview } from 'components/preview/data-preview';
+import { PinboardTrackAndPreselect } from '../components/curation/pinboard-track-and-preselect';
 
 const Curation = () => {
 	const { section: id } = useParams();
@@ -134,6 +135,10 @@ const Curation = () => {
 					}}
 				></Tabs>
 			</div>
+			<PinboardTrackAndPreselect
+				maybeComposerId={state?.body?.composerId}
+				maybeTitle={state?.body?.title}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
Co-authored-by: @frederickobrien 

https://trello.com/c/ryaNbPFY/1866-pinboard-in-recipeasy

@pradasa and @frederickobrien had the wonderful idea to add [Pinboard](https://github.com/guardian/pinboard) to the Recipeasy app, where journalists (freelancers most likely) will be vetting the AI generated structured data before approving - this will likely generate some discussion for some pieces… what better place than [Pinboard](https://github.com/guardian/pinboard).

<img width="1829" alt="image" src="https://github.com/guardian/recipes/assets/11380557/c178d8bf-885c-456b-bc3f-c609e48b4e12">

As per usual adding Pinboard to the tool was just a matter of adding the script tag (see `app/views/index.scala.html`).

However, in order to have dedicated pinboard chats per recipe, each underlying composer piece needs to be tracked in workflow (which also gives the benefit of being able to be across all the 'Recipe Data' conversations in one place - see https://github.com/guardian/pinboard/pull/219).

This PR adds a new component `PinboardTrackAndPreselect` which looks up the composer ID in workflow to see if its tracked and if not tracks it (both facilitated by https://github.com/guardian/workflow-frontend/pull/412) then adds the `<pinboard-preselect>` tag to the page passing the composerId to the `data-composer-id` attribute (just like how pinboards are preselected when viewing an article in composer) and Pinboard reacts accordingly.

### Prerequisites
- https://github.com/guardian/workflow-frontend/pull/412