### PR TITLE
Prevent infinite fetch on homepage

### DIFF
--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -33,16 +33,12 @@ const Home = (): JSX.Element => {
 		setDisplayedRecipes(recipes);
 	}, [recipeList, listFilter]);
 
-	fetch(listEndpoint)
-		.then((response) => {
-			return response.json();
-		})
-		.then((data) => {
-			setList(data);
-		})
-		.catch(() => {
-			return null;
-		});
+	useEffect(() => {
+		fetch(listEndpoint)
+			.then((response) => response.json())
+			.then((data) => setList(data))
+			.catch(() => null);
+	}, []);
 
 	const counterStyles = css`
 		position: fixed;


### PR DESCRIPTION
This wraps the fetch request to the recipes list endpoint so that it doesn't get stuck in an infinite loop. 