### PR TITLE
Add `featuredImage` field to backend model, display in summary UI

### DIFF
--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -15,6 +15,7 @@ case class Timing(qualifier: String, durationInMins: Int, text: Option[String])
 case class Recipe(
   isAppReady: Boolean,
   id: String,
+  featuredImage: Option[String],
   composerId: Option[String],
   webPublicationDate: Option[String],
   canonicalArticle: Option[String],
@@ -82,6 +83,10 @@ object Recipe extends Logging {
     def writes(recipe: Recipe) = Json.obj(
         "isAppReady" -> recipe.isAppReady,
         "id" -> recipe.id,
+        "featuredImage" -> recipe.featuredImage,
+        "composerId" -> recipe.composerId,
+        "webPublicationDate" -> recipe.webPublicationDate,
+        "canonicalArticle" -> recipe.canonicalArticle,
         "serves" -> recipe.serves,
         "ingredients" -> recipe.ingredients,
         "instructions" -> recipe.instructions,

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -47,6 +47,18 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 				</div>
 			</div>
 			<div>
+				<small>Featured image Grid ID</small>
+
+				<div>
+					<a
+						href={`https://media.gutools.co.uk/images/${recipeData.featuredImage}`}
+						target="_blank"
+					>
+						{recipeData.featuredImage}
+					</a>
+				</div>
+			</div>
+			<div>
 				<small>Title</small>
 				<div>{recipeData.title}</div>
 			</div>


### PR DESCRIPTION
This addresses an issue raised by Anna B where featured images selected in the Hatch UI weren't being saved to the curated database. This was because the updated `featuredImage` field wasn't fully represented in the backend. 

This has been fixed, and a link to the original Grid image is now included in the summary view, like so:

<img width="1694" alt="image" src="https://github.com/guardian/recipes/assets/11380557/ec03997f-6fec-4a02-a24f-8773b2558b04">

This isn't the first time something's slipped through the net (see https://github.com/guardian/recipes/pull/62). I'd like like to tighten/unify the types somehow, or at least test more thoroughly going forward as this kind of human error could lead to a lot of good data being lost once curation ramps up.