### PR TITLE
Data reset endpoint and UI confirmation check

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -544,6 +544,19 @@ class ApiController (
     }
   }
 
+  def dbRaw(id: String) = Action {
+    val key_to_get = MMap(config.hashKey -> new AttributeValue(id)).asJava;
+    def request(tableName: String) = new GetItemRequest()
+        .withKey(key_to_get)
+        .withTableName(tableName);
+    val rawData = dbClient.getItem(request(config.rawRecipesTableName)).getItem();
+    if (rawData == null) {
+      NotFound("No recipe with %s: '%s'.".format(config.hashKey, id))
+    } else {
+      Ok(Json.parse(ItemUtils.toItem(rawData).toJSON()));
+    }
+  }
+
   def get_list() = Action {
     // Get a list of recipes
 

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable.{Map => MMap}
 case class Quantity(absolute: Option[String], from: Option[String], to: Option[String])
 case class Range(min: Double, max: Double)
 case class Ingredient(name: String, amount: Option[Range], unit: Option[String], ingredientId: Option[String], prefix: Option[String], suffix: Option[String], optional: Option[Boolean], text: Option[String])
-case class IngredientsList(recipeSection: String, ingredientsList: List[Ingredient])
+case class IngredientsList(recipeSection: Option[String], ingredientsList: List[Ingredient])
 case class Serves(amount: Range, unit: String, text: Option[String])
 case class Instruction(stepNumber: Int, description: String, images: Option[List[String]])
 case class Timing(qualifier: String, durationInMins: Int, text: Option[String])

--- a/conf/routes
+++ b/conf/routes
@@ -10,6 +10,7 @@ GET     /api/curation/*id           controllers.ApiController.index(id)
 +nocsrf
 POST    /api/curation/*id           controllers.ApiController.postId(id)
 GET     /api/db/*id                 controllers.ApiController.db(id)
+GET     /api/db-raw/*id             controllers.ApiController.dbRaw(id)
 GET     /api/list                   controllers.ApiController.get_list
 GET     /api/list/*id               controllers.ApiController.list(id)
 

--- a/recipes-client/components/footer.tsx
+++ b/recipes-client/components/footer.tsx
@@ -79,9 +79,9 @@ const resetRecipe = (
 			payload: '[Reset] Error: No article id provided.',
 		});
 	} else {
-		const articleUrl = aId.replace(/^\/+/, '');
+		const recipeId = aId.replace(/^\/+/, '');
 		void fetchAndDispatch(
-			`${location.origin}/api/db/${articleUrl}`,
+			`${location.origin}/api/db-raw/${recipeId}`,
 			actions.init,
 			'body',
 			dispatcher,
@@ -125,6 +125,14 @@ const Footer = (props: FooterProps): JSX.Element | JSX.Element[] => {
 	};
 
 	const reset = (event: React.MouseEvent<HTMLInputElement>): void => {
+		if (
+			!window.confirm(
+				'Are you sure you want to reset? Doing so will return this recipe data to the original raw state produced by our machine learning model. Any edits you have made will be lost.',
+			)
+		) {
+			event.preventDefault();
+			return;
+		}
 		event.preventDefault();
 		resetRecipe(articleId, dispatcher);
 	};

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -48,14 +48,17 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 			</div>
 			<div>
 				<small>Featured image Grid ID</small>
-
 				<div>
-					<a
-						href={`https://media.gutools.co.uk/images/${recipeData.featuredImage}`}
-						target="_blank"
-					>
-						{recipeData.featuredImage}
-					</a>
+					{recipeData.featuredImage ? (
+						<a
+							href={`https://media.gutools.co.uk/images/${recipeData.featuredImage}`}
+							target="_blank"
+						>
+							{recipeData.featuredImage}
+						</a>
+					) : (
+						'-'
+					)}
 				</div>
 			</div>
 			<div>

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -96,7 +96,7 @@ export interface Range {
 }
 
 export type IngredientsGroup = {
-	recipeSection: string;
+	recipeSection?: string;
 	ingredientsList: Ingredient[];
 };
 

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -87,21 +87,21 @@ const Home = (): JSX.Element => {
 						name="filter"
 						value="all"
 						label="All"
-						onClick={() => setListFilter('all')}
+						onChange={() => setListFilter('all')}
 						checked={listFilter === 'all'}
 					/>
 					<Radio
 						name="filter"
 						value="curated"
 						label="Curated"
-						onClick={() => setListFilter('curated')}
+						onChange={() => setListFilter('curated')}
 						checked={listFilter === 'curated'}
 					/>
 					<Radio
 						name="filter"
 						value="non-curated"
 						label="Awaiting curation"
-						onClick={() => setListFilter('non-curated')}
+						onChange={() => setListFilter('non-curated')}
 						checked={listFilter === 'non-curated'}
 					/>
 				</RadioGroup>


### PR DESCRIPTION
This adjusts the endpoints in the backend so that the 'Reset' button works as desired (reverting the recipe to its raw ML form) and adding a final confirmation check after the button is pressed so users know what they're getting themselves into.

<img width="1714" alt="image" src="https://github.com/guardian/recipes/assets/11380557/5d977b40-16b2-4a0d-a504-720be80fe73b">

Also a couple of other tweaks - showing dashes in the data preview when `featuredImage` is empty and changing `onClick` to `onChange` for the homepage radio buttons.