### PR TITLE
Display recipe ID and canonical article in summary view

### DIFF
--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -47,6 +47,18 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 				</div>
 			</div>
 			<div>
+				<small>Recipe ID</small>
+				<div>{recipeData.id}</div>
+			</div>
+			<div>
+				<small>Canonical article</small>
+				<div>
+					<a href={recipeData.canonicalArticle} target="_blank">
+						{recipeData.canonicalArticle}
+					</a>
+				</div>
+			</div>
+			<div>
 				<small>Featured image Grid ID</small>
 				<div>
 					{recipeData.featuredImage ? (


### PR DESCRIPTION
As requested by @guardian-ben, this updates the data preview component to display a recipe's ID and provide a link to the canonical article. 

<img width="1695" alt="image" src="https://github.com/guardian/recipes/assets/11380557/358e863c-08bd-4100-94e0-91278d3e17c9">

As the interplay between Hatch, CoPip, and the app continues to grow it's handy to have this visible.