### PR TITLE
More natural unit presentation in data preview

### DIFF
--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -9,8 +9,39 @@ interface DataPreviewProps {
 	recipeData: AllRecipeFields | null;
 }
 
+const prettifyNumber = (num: number): string => {
+	if (num % 1 === 0) {
+		return num.toString();
+	} else {
+		switch (num) {
+			case 0.25:
+				return '¼';
+			case 0.33:
+				return '⅓';
+			case 0.5:
+				return '½';
+			case 0.66:
+				return '⅔';
+			case 0.75:
+				return '¾';
+			case 1.5:
+				return '1½';
+			case 2.5:
+				return '2½';
+			case 3.5:
+				return '3½';
+			case 4.5:
+				return '4½';
+			default:
+				return num.toString();
+		}
+	}
+};
+
 const prettifyRange = (amount: Range) => {
-	return amount.min === amount.max ? amount.min : `${amount.min}-${amount.max}`;
+	return amount.min === amount.max
+		? prettifyNumber(amount.min)
+		: `${amount.min}-${amount.max}`;
 };
 
 const prettifyDurationInMins = (durationInMins: number): string => {
@@ -28,12 +59,15 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 		suffix,
 	}: Ingredient) => {
 		const concernsTins = unit?.includes('tin');
-		const tbsOrTsp = unit?.includes('tbsp') || unit?.includes('tsp');
-		return `${amount ? prettifyRange(amount) : ''}${tbsOrTsp ? ' ' : ''}${
-			concernsTins ? ' x ' : ''
-		}${unit ? unit : ''} ${prefix ? prefix : ''} ${name} ${
-			suffix ? suffix : ''
-		}`;
+		const isUnitRequiringSpace =
+			unit?.includes('tbsp') ||
+			unit?.includes('tsp') ||
+			unit?.includes('clove');
+		return `${amount ? prettifyRange(amount) : ''}${
+			isUnitRequiringSpace ? ' ' : ''
+		}${concernsTins ? ' x ' : ''}${unit ? unit : ''} ${
+			prefix ? prefix : ''
+		} ${name} ${suffix ? suffix : ''}`;
 	};
 
 	return recipeData === null ? (


### PR DESCRIPTION
As requested by Anna B this adds more custom rules for ingredients in the data preview section of curation pages. Fractions will be presented more naturally (e.g. `1.5` will be displayed as '1½'.

<img width="512" alt="image" src="https://github.com/guardian/recipes/assets/11380557/21103407-2ea1-4aa7-bce7-35dae89dd3f3">

As ever probably not the most elegant solution but it should capture a huge majority of cases. The goal is to make curating as smooth as possible and these changes move the needle.