### PR TITLE
Store `featuredImage` objects  instead of Grid IDs as strings

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -226,7 +226,38 @@ class ApiController (
             }
         },
         "featuredImage": {
-            "type": ["string", "null"]
+            "type": ["object", "null"],
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "mediaId": {
+                    "type": "string"
+                },
+                "cropId": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "photographer": {
+                    "type": "string"
+                },
+                "imageType": {
+                    "type": "string"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "mediaApiUrl": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url",
+                "mediaId",
+                "cropId"
+            ]
         },
         "timings": {
           "type": "array",

--- a/app/model/Recipe.scala
+++ b/app/model/Recipe.scala
@@ -11,11 +11,12 @@ case class IngredientsList(recipeSection: Option[String], ingredientsList: List[
 case class Serves(amount: Range, unit: String, text: Option[String])
 case class Instruction(stepNumber: Int, description: String, images: Option[List[String]])
 case class Timing(qualifier: String, durationInMins: Int, text: Option[String])
+case class ImageObject(url: String, mediaId: String, cropId: String, source: Option[String], photographer: Option[String], imageType: Option[String], caption: Option[String], mediaApiUrl: Option[String])
 
 case class Recipe(
   isAppReady: Boolean,
   id: String,
-  featuredImage: Option[String],
+  featuredImage: Option[ImageObject],
   composerId: Option[String],
   webPublicationDate: Option[String],
   canonicalArticle: Option[String],
@@ -38,6 +39,10 @@ case class Recipe(
 
 object Quantity {
   implicit val formats: OFormat[Quantity] = Json.format[Quantity]
+}
+
+object ImageObject {
+  implicit val formats: OFormat[ImageObject] = Json.format[ImageObject]
 }
 
 object Ingredient {

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -6,13 +6,6 @@ import { ActionType } from '../../interfaces/main';
 import minBy from 'lodash-es/minBy';
 import { actions } from '../../actions/recipeActions';
 
-interface ImagePickerProps {
-	isLoading: boolean;
-	html: Record<string, unknown> | null;
-	selected: string | null;
-	dispatcher: Dispatch<ActionType>;
-}
-
 type assetsInfo = {
 	assets: imageInfo[];
 };
@@ -62,9 +55,6 @@ const getPictureIds = (elems: assetsInfo[] | undefined): string[] => {
 		);
 	}
 };
-// function getSelectedPic(body: Record<string, string>): string {
-//   return body['picture']
-// }
 
 const select = (
 	objId: string,
@@ -78,13 +68,19 @@ const select = (
 	});
 };
 
-const PictureGrid = (props: {
-	pics: string[];
+interface PictureGridProps {
+	picUrls: string[];
 	picIds: string[];
 	selected: string | null;
 	dispatcher: Dispatch<ActionType>;
-}) => {
-	const { pics, picIds, selected, dispatcher } = props;
+}
+
+const PictureGrid = ({
+	picUrls,
+	picIds,
+	selected,
+	dispatcher,
+}: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
 	return (
 		<>
@@ -104,13 +100,13 @@ const PictureGrid = (props: {
 					borderWidth: '2px',
 				}}
 			>
-				{pics.map((p, i) => {
+				{picUrls.map((p, i) => {
 					return (
 						<div
 							onMouseOver={() => setHover(i)}
 							onMouseOut={() => setHover(-1)}
 							onClick={() =>
-								select(picIds[i], picIds[i] === selected, dispatcher)
+								select(picUrls[i], picUrls[i] === selected, dispatcher)
 							}
 							css={{
 								gridArea: `${Math.floor(i / 5 + 1)}`,
@@ -139,10 +135,8 @@ const PictureGrid = (props: {
 								}}
 							>
 								<CheckButton
-									objId={picIds[i]}
-									isSelected={picIds[i] === selected}
+									isSelected={picUrls[i] === selected}
 									hover={i === picHovered}
-									dispatcher={dispatcher}
 								/>
 							</div>
 						</div>
@@ -154,8 +148,19 @@ const PictureGrid = (props: {
 	);
 };
 
-const ImagePicker = (props: ImagePickerProps): JSX.Element => {
-	const { isLoading, html, selected, dispatcher } = props;
+interface ImagePickerProps {
+	isLoading: boolean;
+	html: Record<string, unknown> | null;
+	selected: string | null;
+	dispatcher: Dispatch<ActionType>;
+}
+
+const ImagePicker = ({
+	isLoading,
+	html,
+	selected,
+	dispatcher,
+}: ImagePickerProps): JSX.Element => {
 	if (isLoading || html === null) {
 		return <h3> Loading pictures... </h3>;
 	} else {
@@ -164,7 +169,7 @@ const ImagePicker = (props: ImagePickerProps): JSX.Element => {
 
 		return (
 			<PictureGrid
-				pics={picUrls}
+				picUrls={picUrls}
 				picIds={picIds}
 				selected={selected}
 				dispatcher={dispatcher}

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -5,6 +5,7 @@ import CheckButton from '../reusables/check-button';
 import { ActionType } from '../../interfaces/main';
 import minBy from 'lodash-es/minBy';
 import { actions } from '../../actions/recipeActions';
+import { ImageObject } from '../../interfaces/main';
 
 type assetsInfo = {
 	assets: imageInfo[];
@@ -16,7 +17,16 @@ type imageInfo = {
 };
 
 type typeDataTypes = {
+	altText: string;
+	caption: string;
+	credit: string;
+	displayCredit: string;
 	height: string;
+	imageType: string;
+	mediaApiUri: string;
+	mediaId: string;
+	secureFile: string;
+	source: string;
 	width: string;
 };
 
@@ -25,43 +35,48 @@ const findSmallestVersion = (assets: imageInfo[]): imageInfo => {
 	return minBy(assets, ({ typeData }) => typeData.width);
 };
 
-const getPictureUrls = (elems: assetsInfo[] | undefined): string[] => {
-	if (elems === undefined) {
-		return [];
+const inferCropId = (url: string): string => {
+	const parts = url.split('/');
+	const cropId = parts[parts.length - 2];
+	if (cropId !== undefined) {
+		return cropId;
 	} else {
-		return Array.from(
-			elems.reduce((acc, el) => {
-				const smallestAsset = findSmallestVersion(el['assets']);
-				if ('file' in smallestAsset) {
-					acc.add(smallestAsset['file']);
-				}
-				return acc;
-			}, new Set<string>()),
-		);
+		console.error('Could not infer cropId from url: ', url);
+		return '';
 	}
 };
 
-const getPictureIds = (elems: assetsInfo[] | undefined): string[] => {
+const getPictureObjects = (elems: assetsInfo[] | undefined): ImageObject[] => {
 	if (elems === undefined) {
 		return [];
 	} else {
-		return Array.from(
-			elems.reduce((acc, el) => {
-				if ('id' in el) {
-					acc.add(el['id']);
-				}
-				return acc;
-			}, new Set<string>()),
-		);
+		return elems.reduce((acc, el) => {
+			const smallestAsset = findSmallestVersion(el.assets);
+			if (smallestAsset.file) {
+				acc.push({
+					url: smallestAsset.file,
+					mediaId: smallestAsset.typeData.mediaId,
+					cropId: inferCropId(smallestAsset.file),
+					source: smallestAsset.typeData.source,
+					photographer: smallestAsset.typeData.displayCredit,
+					imageType: smallestAsset.typeData.imageType,
+					caption: smallestAsset.typeData.caption,
+					mediaApiUri: smallestAsset.typeData.mediaApiUri,
+				});
+			}
+			return acc;
+		}, [] as ImageObject[]);
 	}
 };
 
 const select = (
-	objId: string,
+	imageObject: ImageObject,
 	isSelected: boolean,
+	setSelectedImage: Dispatch<ImageObject | null>,
 	dispatcher: Dispatch<ActionType>,
 ): void => {
-	const obj = isSelected ? null : objId;
+	const obj = isSelected ? null : imageObject;
+	setSelectedImage(obj);
 	dispatcher({
 		type: actions.selectImg,
 		payload: obj,
@@ -69,16 +84,16 @@ const select = (
 };
 
 interface PictureGridProps {
-	picUrls: string[];
-	picIds: string[];
-	selected: string | null;
+	picObjects: ImageObject[];
+	selectedImage: ImageObject | null;
+	setSelectedImage: Dispatch<ImageObject | null>;
 	dispatcher: Dispatch<ActionType>;
 }
 
 const PictureGrid = ({
-	picUrls,
-	picIds,
-	selected,
+	picObjects,
+	selectedImage,
+	setSelectedImage,
 	dispatcher,
 }: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
@@ -100,13 +115,18 @@ const PictureGrid = ({
 					borderWidth: '2px',
 				}}
 			>
-				{picUrls.map((p, i) => {
+				{picObjects.map((p, i) => {
 					return (
 						<div
 							onMouseOver={() => setHover(i)}
 							onMouseOut={() => setHover(-1)}
 							onClick={() =>
-								select(picUrls[i], picUrls[i] === selected, dispatcher)
+								select(
+									picObjects[i],
+									picObjects[i] === selectedImage,
+									setSelectedImage,
+									dispatcher,
+								)
 							}
 							css={{
 								gridArea: `${Math.floor(i / 5 + 1)}`,
@@ -122,7 +142,7 @@ const PictureGrid = ({
 							}}
 							key={`img_${i}`}
 						>
-							<img style={{ maxWidth: 'inherit' }} src={p} alt={p} />
+							<img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
 							<div
 								key={`tile-icon-bar-${i}`}
 								style={{
@@ -135,7 +155,7 @@ const PictureGrid = ({
 								}}
 							>
 								<CheckButton
-									isSelected={picUrls[i] === selected}
+									isSelected={picObjects[i]?.url === selectedImage?.url}
 									hover={i === picHovered}
 								/>
 							</div>
@@ -151,27 +171,28 @@ const PictureGrid = ({
 interface ImagePickerProps {
 	isLoading: boolean;
 	html: Record<string, unknown> | null;
-	selected: string | null;
+	selectedImage: ImageObject | null;
+	setSelectedImage: (img: ImageObject | null) => void;
 	dispatcher: Dispatch<ActionType>;
 }
 
 const ImagePicker = ({
 	isLoading,
 	html,
-	selected,
+	selectedImage,
+	setSelectedImage,
 	dispatcher,
 }: ImagePickerProps): JSX.Element => {
 	if (isLoading || html === null) {
 		return <h3> Loading pictures... </h3>;
 	} else {
-		const picUrls = getPictureUrls(html['elements']);
-		const picIds = getPictureIds(html['elements']);
+		const picObjects = getPictureObjects(html.elements as assetsInfo[]);
 
 		return (
 			<PictureGrid
-				picUrls={picUrls}
-				picIds={picIds}
-				selected={selected}
+				picObjects={picObjects}
+				selectedImage={selectedImage}
+				setSelectedImage={setSelectedImage}
 				dispatcher={dispatcher}
 			/>
 		);

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -59,15 +59,14 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 				</div>
 			</div>
 			<div>
-				<small>Featured image Grid ID</small>
+				<small>Featured image</small>
 				<div>
 					{recipeData.featuredImage ? (
-						<a
-							href={`https://media.gutools.co.uk/images/${recipeData.featuredImage}`}
-							target="_blank"
-						>
-							{recipeData.featuredImage}
-						</a>
+						<img
+							src={recipeData.featuredImage}
+							alt={`Featured image of ${recipeData.title} recipe`}
+							css={imageStyles}
+						/>
 					) : (
 						'-'
 					)}
@@ -223,4 +222,9 @@ const previewStyles = css`
 	div {
 		margin-bottom: 1rem;
 	}
+`;
+
+const imageStyles = css`
+	max-width: 50%;
+	height: auto;
 `;

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -63,7 +63,7 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 				<div>
 					{recipeData.featuredImage ? (
 						<img
-							src={recipeData.featuredImage}
+							src={recipeData.featuredImage.url}
 							alt={`Featured image of ${recipeData.title} recipe`}
 							css={imageStyles}
 						/>

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -59,7 +59,7 @@ export interface RecipeFields {
 	webPublicationDate: string; // Date recipe was published
 	title: string; // Name of the recipe
 	description: string; // Short description of the recipe
-	featuredImage: string; // !! Actually capiImage
+	featuredImage: ImageObject; // !! Actually capiImage
 	contributors: ContributorTag[]; // Structured data for contributors, where available
 	byline: BylineEntry[]; // Authorship data for the piece, including references to contributors where available, and text where not. Accommodates cases like this
 	ingredients: IngredientsGroup[]; // List of ingredients
@@ -74,6 +74,17 @@ export interface RecipeFields {
 	timings: Timing[];
 	instructions: Instruction[]; // Steps breaking down the recipe. For recipes that can't be stepified this would just be one big 'step' containing the method
 }
+
+export type ImageObject = {
+	url: string;
+	mediaId: string;
+	cropId: string;
+	source?: string;
+	photographer?: string;
+	imageType?: string;
+	caption?: string;
+	mediaApiUri?: string;
+};
 
 export type DifficultyLevel = 'easy' | 'medium' | 'hard';
 export interface Instruction {

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -19,13 +19,14 @@ import { fetchAndDispatch, setLoadingFinished } from '../utils/requests';
 import { Tabs } from '@guardian/source-react-components-development-kitchen';
 import { DataPreview } from 'components/preview/data-preview';
 import { PinboardTrackAndPreselect } from '../components/curation/pinboard-track-and-preselect';
+import { ImageObject } from 'interfaces/main';
 
 const Curation = () => {
 	const { section: id } = useParams();
 	const articleId = id ? `/${id}` : '';
 	const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
 	const [capiId, setCapiId] = useState<string | null>(null);
-	const image = state.body === null ? null : state.body.featuredImage;
+	const [selectedImage, setSelectedImage] = useState<ImageObject | null>(null);
 	const scrubbedId = articleId.replace(/^\/+/, '');
 
 	const [selectedTab, setSelectedTab] = useState('summary');
@@ -68,6 +69,7 @@ const Curation = () => {
 				if (state.body === null) {
 					return;
 				}
+				setSelectedImage(state.body.featuredImage);
 				setCapiId(state.body.canonicalArticle);
 				fetchAndDispatch(
 					`${location.origin}${capiProxy}/${state.body.canonicalArticle}`,
@@ -95,7 +97,8 @@ const Curation = () => {
 				<>
 					<ImagePicker
 						html={state.html}
-						selected={image}
+						selectedImage={selectedImage}
+						setSelectedImage={setSelectedImage}
 						isLoading={state.isLoading}
 						dispatcher={dispatch}
 					/>


### PR DESCRIPTION
Following discussions among @guardian/basecamp and @guardian/content-platforms about what's needed from the `featuredImage` field for recipe data, this adjusts the model and UI to expect rich objects rather than strings.

The UI has also been improved, with the data preview displaying the chosen image.

<img width="1694" alt="image" src="https://github.com/guardian/recipes/assets/11380557/447286ed-1e84-466e-bc8f-3776f37f2500">

There is scope to follow up on this with a PR taking advantage of existing Pinboard integration (#65). At present image options are still limited to those that appear in the recipe's canonical article. Longer term we want users to be able to use any image from the grid. Using the drag and drop loveliness of Pinboard this feels very doable.

Before this can be safely merged the curated data needs to have its `featuredImage` fields cleared.