### PR TITLE
Buttons to add and remove timings

### DIFF
--- a/recipes-client/components/form/form-buttons.tsx
+++ b/recipes-client/components/form/form-buttons.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { Button } from '@guardian/source-react-components';
 import { ActionType, SchemaItem } from 'interfaces/main';
+import { servesSchema } from 'interfaces/nastyHardcodedSchemas';
 import { Dispatch } from 'react';
 import { handleAddField, handleRemoveField } from './form-input-handlers';
 
@@ -11,6 +12,9 @@ export const getItemButtons = (
 	formFieldsSchema: SchemaItem,
 	dispatcher: Dispatch<ActionType>,
 ): JSX.Element => {
+	if (key === 'timings') {
+		formFieldsSchema = formFieldsSchema.properties;
+	}
 	return (
 		<div css={{ marginTop: '5px' }}>
 			<FormButton

--- a/recipes-client/components/form/inputs/instructions.tsx
+++ b/recipes-client/components/form/inputs/instructions.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 
-import { Legend } from '@guardian/source-react-components';
 import { ActionType, Instruction, SchemaItem } from 'interfaces/main';
 import { Dispatch } from 'react';
 import { getItemButtons } from '../form-buttons';

--- a/recipes-client/consts/index.ts
+++ b/recipes-client/consts/index.ts
@@ -114,7 +114,7 @@ export const UIschema: UIschemaItem = {
 	timings: {
 		'ui:display': true,
 		'ui:locked': false,
-		'ui:removable': false,
+		'ui:removable': true,
 		'ui:order': ['qualifier', 'durationInMins'],
 		qualifier: {
 			'ui:display': true,

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -114,6 +114,7 @@ export interface Ingredient {
 export type Timing = {
 	qualifier: string; // e.g. 'passive', 'active', 'set', 'chill'
 	durationInMins: number;
+	text?: string; // Original text
 };
 
 export interface Serves {


### PR DESCRIPTION
As raised by Anna B, users had no way of adding them if there were none there. Not good!

Now they can:

<img width="1693" alt="image" src="https://github.com/guardian/recipes/assets/11380557/aaf297e4-f3b7-48f4-95d8-7247ca9fc88f">
