### PR TITLE
Enable nightly backups for DynamoDB tables

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -7,5 +7,6 @@ export const prodProps = {
   stack: "playground",
   stage: "PROD",
   env: { region: "eu-west-1" },
+  withBackup: true,
 };
 new Recipes(app, "Recipes-euwest-1-PROD", prodProps);

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,4 +3,9 @@ import { GuRoot } from "@guardian/cdk/lib/constructs/root";
 import { Recipes } from "../lib/recipes";
 
 const app = new GuRoot();
-new Recipes(app, "Recipes-euwest-1-PROD", { stack: "playground", stage: "PROD", env: { region: "eu-west-1" } });
+export const prodProps = {
+  stack: "playground",
+  stage: "PROD",
+  env: { region: "eu-west-1" },
+};
+new Recipes(app, "Recipes-euwest-1-PROD", prodProps);

--- a/cdk/lib/__snapshots__/recipes.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes.test.ts.snap
@@ -76,11 +76,11 @@ exports[`The Recipes stack matches the snapshot 1`] = `
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
           "LaunchTemplateId": {
-            "Ref": "playgroundTESTrecipesC8C65EB2",
+            "Ref": "playgroundPRODrecipes441F470D",
           },
           "Version": {
             "Fn::GetAtt": [
-              "playgroundTESTrecipesC8C65EB2",
+              "playgroundPRODrecipes441F470D",
               "LatestVersionNumber",
             ],
           },
@@ -118,7 +118,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           {
             "Key": "Stage",
             "PropagateAtLaunch": true,
-            "Value": "TEST",
+            "Value": "PROD",
           },
           {
             "Key": "SystemdUnit",
@@ -164,7 +164,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "ValidationMethod": "DNS",
@@ -184,7 +184,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "Stage": "TEST",
+        "Stage": "PROD",
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
@@ -230,7 +230,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                     {
                       "Ref": "DistributionBucketName",
                     },
-                    "/playground/TEST/recipes/*",
+                    "/playground/PROD/recipes/*",
                   ],
                 ],
               },
@@ -278,7 +278,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -322,11 +322,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -398,7 +394,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },
@@ -570,7 +566,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "Type": "application",
@@ -608,7 +604,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -670,15 +666,11 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/playground/recipes",
+                    ":parameter/PROD/playground/recipes",
                   ],
                 ],
               },
@@ -693,15 +685,11 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/playground/recipes/*",
+                    ":parameter/PROD/playground/recipes/*",
                   ],
                 ],
               },
@@ -746,7 +734,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "TargetGroupAttributes": [
@@ -801,7 +789,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -854,7 +842,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
         "SSESpecification": {
           "SSEEnabled": true,
         },
-        "TableName": "curatedRecipesTableTEST",
+        "TableName": "curatedRecipesTablePROD",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -870,14 +858,14 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
-    "playgroundTESTrecipesC8C65EB2": {
+    "playgroundPRODrecipes441F470D": {
       "DependsOn": [
         "InstanceRoleRecipesDefaultPolicy207A92A7",
         "InstanceRoleRecipes248BE506",
@@ -887,7 +875,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
           "IamInstanceProfile": {
             "Arn": {
               "Fn::GetAtt": [
-                "playgroundTESTrecipesProfile44E4F03F",
+                "playgroundPRODrecipesProfile76BE93F6",
                 "Arn",
               ],
             },
@@ -927,7 +915,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "Recipes/playground-TEST-recipes",
+                  "Value": "Recipes/playground-PROD-recipes",
                 },
                 {
                   "Key": "Stack",
@@ -935,7 +923,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -952,7 +940,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "Recipes/playground-TEST-recipes",
+                  "Value": "Recipes/playground-PROD-recipes",
                 },
                 {
                   "Key": "Stack",
@@ -960,7 +948,7 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -972,25 +960,17 @@ exports[`The Recipes stack matches the snapshot 1`] = `
                 [
                   "#!/bin/bash -ev
 mkdir /etc/gu
-echo 'TEST' > /etc/gu/stage
-aws --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  " s3 cp s3://",
+echo 'PROD' > /etc/gu/stage
+aws --region eu-west-1 s3 cp s3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/playground/TEST/recipes/recipes.conf /etc/gu/recipes.conf
-aws --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  " s3 cp s3://",
+                  "/playground/PROD/recipes/recipes.conf /etc/gu/recipes.conf
+aws --region eu-west-1 s3 cp s3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/playground/TEST/recipes/recipes.deb /tmp/package.deb
+                  "/playground/PROD/recipes/recipes.deb /tmp/package.deb
 dpkg -i /tmp/package.deb",
                 ],
               ],
@@ -1011,7 +991,7 @@ dpkg -i /tmp/package.deb",
               },
               {
                 "Key": "Name",
-                "Value": "Recipes/playground-TEST-recipes",
+                "Value": "Recipes/playground-PROD-recipes",
               },
               {
                 "Key": "Stack",
@@ -1019,7 +999,7 @@ dpkg -i /tmp/package.deb",
               },
               {
                 "Key": "Stage",
-                "Value": "TEST",
+                "Value": "PROD",
               },
             ],
           },
@@ -1027,7 +1007,7 @@ dpkg -i /tmp/package.deb",
       },
       "Type": "AWS::EC2::LaunchTemplate",
     },
-    "playgroundTESTrecipesProfile44E4F03F": {
+    "playgroundPRODrecipesProfile76BE93F6": {
       "Properties": {
         "Roles": [
           {
@@ -1060,7 +1040,7 @@ dpkg -i /tmp/package.deb",
         "SSESpecification": {
           "SSEEnabled": true,
         },
-        "TableName": "rawRecipesTableTEST",
+        "TableName": "rawRecipesTablePROD",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1076,7 +1056,7 @@ dpkg -i /tmp/package.deb",
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/recipes.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes.test.ts.snap
@@ -845,6 +845,10 @@ exports[`The Recipes stack matches the snapshot 1`] = `
         "TableName": "curatedRecipesTablePROD",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1042,6 +1046,10 @@ dpkg -i /tmp/package.deb",
         },
         "TableName": "rawRecipesTablePROD",
         "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/recipes.test.ts
+++ b/cdk/lib/recipes.test.ts
@@ -1,11 +1,12 @@
 import { App } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { prodProps } from "../bin/cdk";
 import { Recipes } from "./recipes";
 
 describe("The Recipes stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const stack = new Recipes(app, "Recipes", { stack: "playground", stage: "TEST" });
+    const stack = new Recipes(app, "Recipes", prodProps);
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
   });

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,14 +8,14 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "52.0.0",
+        "@guardian/cdk": "52.3.0",
         "@guardian/eslint-config-typescript": "7.0.0",
         "@guardian/prettier": "5.0.0",
         "@guardian/tsconfig": "^0.2.0",
         "@types/jest": "^29.5.6",
         "@types/node": "20.8.8",
-        "aws-cdk": "2.100.0",
-        "aws-cdk-lib": "2.100.0",
+        "aws-cdk": "2.109.0",
+        "aws-cdk-lib": "2.109.0",
         "constructs": "10.3.0",
         "eslint": "^8.50.0",
         "jest": "^29.7.0",
@@ -1370,19 +1370,19 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "52.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.0.0.tgz",
-      "integrity": "sha512-aotpEZ8w6/etgSyPDviLdAeLNxHhHJkkSgyvZ2xTFaqskJ32WpYHNe6MJgn84HaSL0034p0fdMjsQwrm9VDhHg==",
+      "version": "52.3.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.3.0.tgz",
+      "integrity": "sha512-3TKuGYPh5ScRUGNL2u6Y3p5aSAGxrskVHX+mf4OQl+4uxeGm+tXCHEUg3oQbHi+dZYMVR/OHLEwKgX7VzfPgUw==",
       "dev": true,
       "dependencies": {
         "@changesets/cli": "^2.26.2",
         "@oclif/core": "2.15.0",
-        "aws-cdk-lib": "2.100.0",
-        "aws-sdk": "^2.1469.0",
+        "aws-cdk-lib": "2.109.0",
+        "aws-sdk": "^2.1497.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.91.0",
         "constructs": "10.3.0",
-        "git-url-parse": "^13.1.0",
+        "git-url-parse": "^13.1.1",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
@@ -1394,8 +1394,8 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.100.0",
-        "aws-cdk-lib": "2.100.0",
+        "aws-cdk": "2.109.0",
+        "aws-cdk-lib": "2.109.0",
         "constructs": "10.3.0"
       }
     },
@@ -2709,9 +2709,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
-      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.109.0.tgz",
+      "integrity": "sha512-e06YlA4HsKZCOdh3ApynZauJ3/224o/q5vOso3Fs5ksLkYhfXREl+O7UmAOZ1Nenq5ADNgccvNwuChQWbNSvSg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.100.0.tgz",
-      "integrity": "sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==",
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.109.0.tgz",
+      "integrity": "sha512-Va5j3eOrepm0H7a/VPvzCDRuPAL7z/xYMlrMJdFYHA3G1GmRvXnDgHWTiUYXh1AuBqJ4zUd4StRrBQhufAtHWw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2741,7 +2741,7 @@
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.201",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
@@ -2750,7 +2750,7 @@
         "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
+        "punycode": "^2.3.1",
         "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
@@ -2974,7 +2974,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3066,7 +3066,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3099,9 +3099,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1484.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1484.0.tgz",
-      "integrity": "sha512-emfCmb5j/UtaB7U8tvLpGdVNAlZMg4xZOhoFvL8jBQwIVJyCRyaqcshe31JXTwJdafThn2pNPtQOeYbZJCE0Ow==",
+      "version": "2.1509.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1509.0.tgz",
+      "integrity": "sha512-5h27GXv5/M1Cfgw5StYqTyCesnqscez3QOsKGnShCXP6saGkSEvV3TUHTXQBqdfsrBmz5hVCa8doqP3r3yJD/w==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -10535,19 +10535,19 @@
       "dev": true
     },
     "@guardian/cdk": {
-      "version": "52.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.0.0.tgz",
-      "integrity": "sha512-aotpEZ8w6/etgSyPDviLdAeLNxHhHJkkSgyvZ2xTFaqskJ32WpYHNe6MJgn84HaSL0034p0fdMjsQwrm9VDhHg==",
+      "version": "52.3.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.3.0.tgz",
+      "integrity": "sha512-3TKuGYPh5ScRUGNL2u6Y3p5aSAGxrskVHX+mf4OQl+4uxeGm+tXCHEUg3oQbHi+dZYMVR/OHLEwKgX7VzfPgUw==",
       "dev": true,
       "requires": {
         "@changesets/cli": "^2.26.2",
         "@oclif/core": "2.15.0",
-        "aws-cdk-lib": "2.100.0",
-        "aws-sdk": "^2.1469.0",
+        "aws-cdk-lib": "2.109.0",
+        "aws-sdk": "^2.1497.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.91.0",
         "constructs": "10.3.0",
-        "git-url-parse": "^13.1.0",
+        "git-url-parse": "^13.1.1",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
@@ -11579,21 +11579,21 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
-      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.109.0.tgz",
+      "integrity": "sha512-e06YlA4HsKZCOdh3ApynZauJ3/224o/q5vOso3Fs5ksLkYhfXREl+O7UmAOZ1Nenq5ADNgccvNwuChQWbNSvSg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.100.0.tgz",
-      "integrity": "sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==",
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.109.0.tgz",
+      "integrity": "sha512-Va5j3eOrepm0H7a/VPvzCDRuPAL7z/xYMlrMJdFYHA3G1GmRvXnDgHWTiUYXh1AuBqJ4zUd4StRrBQhufAtHWw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.201",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
@@ -11602,7 +11602,7 @@
         "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
+        "punycode": "^2.3.1",
         "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
@@ -11755,7 +11755,7 @@
           }
         },
         "punycode": {
-          "version": "2.3.0",
+          "version": "2.3.1",
           "bundled": true,
           "dev": true
         },
@@ -11813,7 +11813,7 @@
           }
         },
         "universalify": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -11838,9 +11838,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1484.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1484.0.tgz",
-      "integrity": "sha512-emfCmb5j/UtaB7U8tvLpGdVNAlZMg4xZOhoFvL8jBQwIVJyCRyaqcshe31JXTwJdafThn2pNPtQOeYbZJCE0Ow==",
+      "version": "2.1509.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1509.0.tgz",
+      "integrity": "sha512-5h27GXv5/M1Cfgw5StYqTyCesnqscez3QOsKGnShCXP6saGkSEvV3TUHTXQBqdfsrBmz5hVCa8doqP3r3yJD/w==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,14 +12,14 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "52.0.0",
+    "@guardian/cdk": "52.3.0",
     "@guardian/eslint-config-typescript": "7.0.0",
     "@guardian/prettier": "5.0.0",
     "@guardian/tsconfig": "^0.2.0",
     "@types/jest": "^29.5.6",
     "@types/node": "20.8.8",
-    "aws-cdk": "2.100.0",
-    "aws-cdk-lib": "2.100.0",
+    "aws-cdk": "2.109.0",
+    "aws-cdk-lib": "2.109.0",
     "constructs": "10.3.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up the `recipes` app's DynamoDB tables using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit).

N.B. prior to enabling the backups I upgraded GuCDK and refactored a bit to improve the coverage of the snapshot tests; it will be easiest to review this PR commit by commit.

## How to test

The snapshot change in https://github.com/guardian/recipes/commit/9314f57bfea23515f3e8862756734a8a8cca5724 should be sufficient here.

I will also check that the backups are created as expected after this has been deployed (the backup jobs run overnight so I'll report back the next working day after this is merged).

## How can we measure success?

We will be able to recover (most) data stored in these tables in the unlikely event that they are ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.