### PR TITLE
'Recipes Data' as Pinboard's composer section ID

### DIFF
--- a/recipes-client/components/curation/pinboard-track-and-preselect.tsx
+++ b/recipes-client/components/curation/pinboard-track-and-preselect.tsx
@@ -68,6 +68,9 @@ export const PinboardTrackAndPreselect = ({
 
 	return maybeWorkflowId ? (
 		// @ts-ignore -- this element is not valid JSX but IS meaningful/detected by Pinboard
-		<pinboard-preselect data-composer-id={maybeComposerId}></pinboard-preselect>
+		<pinboard-preselect
+			data-composer-id={maybeComposerId}
+			data-composer-section="Recipes Data"
+		/>
 	) : null;
 };


### PR DESCRIPTION
This adds a 'Recipes Data' composer section ID so that we can group together recipe curation-related Pinboard activity in its metrics dashboard. 