### PR TITLE
Remove DynamoDB scan request limit

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -597,8 +597,7 @@ class ApiController (
     def scanRequest(tableName: String) = new ScanRequest()
         .withTableName(tableName)
         .withProjectionExpression("%s, title, contributors, canonicalArticle, isAppReady".format(partition_alias))
-        .withExpressionAttributeNames(expressionAttributeValues)
-        .withLimit(60);
+        .withExpressionAttributeNames(expressionAttributeValues);
 
     val rawResult = dbClient.scan(scanRequest( config.rawRecipesTableName ));
     val rawResultData = ItemUtils.toItemList(rawResult.getItems()).asScala


### PR DESCRIPTION
I noticed weird behaviour where not all the recipes were appearing in the Hatch dashboard. Visiting individual recipe pages putting the missing ids in the URL works fine so I think the issue was a cap on the number of items scanned.

This has been removed and will hopefully translate to all recipes being fetched and displayed in the Hatch dashboard.