### PR TITLE
Add ⅛ prettification to data preview

### DIFF
--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -14,6 +14,8 @@ const prettifyNumber = (num: number): string => {
 		return num.toString();
 	} else {
 		switch (num) {
+			case 0.13:
+				return '⅛';
 			case 0.25:
 				return '¼';
 			case 0.33:


### PR DESCRIPTION
The data model returns an amount of 0.13 for eighths (of a teaspoon or some such) so this adds a catch condition in the data preview to display a more editorially consistent fraction in the data preview:

### Form

<img width="637" alt="image" src="https://github.com/guardian/recipes/assets/11380557/807a7313-c2ee-46ef-b405-cc973056ccbb">

### Data preview

<img width="355" alt="image" src="https://github.com/guardian/recipes/assets/11380557/b1e0e28b-cd01-4c5d-bd74-709bf048d6b8">
