### PR TITLE
Standalone servings +/- buttons

### DIFF
--- a/recipes-client/components/form/form-buttons.tsx
+++ b/recipes-client/components/form/form-buttons.tsx
@@ -1,7 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import { Button } from '@guardian/source-react-components';
 import { ActionType, SchemaItem } from 'interfaces/main';
-import { methodStepSchema } from 'interfaces/nastyHardcodedSchemas';
+import {
+	methodStepSchema,
+	servesSchema,
+} from 'interfaces/nastyHardcodedSchemas';
 import { Dispatch } from 'react';
 import { handleAddField, handleRemoveField } from './form-input-handlers';
 
@@ -17,6 +20,9 @@ export const getItemButtons = (
 	}
 	if (key === 'instructions') {
 		formFieldsSchema = methodStepSchema;
+	}
+	if (key === 'serves') {
+		formFieldsSchema = servesSchema;
 	}
 	return (
 		<div css={{ marginTop: '5px', display: 'flex', alignItems: 'center' }}>

--- a/recipes-client/components/form/inputs/serves.tsx
+++ b/recipes-client/components/form/inputs/serves.tsx
@@ -40,7 +40,7 @@ export const renderServesFormGroup = (
 		return (
 			<FormItem
 				text={formItems[k]}
-				choices={['people', 'items']}
+				choices={null}
 				label={`${key}.${k}`}
 				key={`${key}.${k}`}
 				dispatcher={dispatcher}

--- a/recipes-client/components/form/inputs/serves.tsx
+++ b/recipes-client/components/form/inputs/serves.tsx
@@ -1,11 +1,10 @@
 /** @jsxImportSource @emotion/react */
 
-import { Legend } from '@guardian/source-react-components';
 import { ActionType, SchemaItem, Serves } from 'interfaces/main';
+import { servesSchema } from 'interfaces/nastyHardcodedSchemas';
 import { Dispatch } from 'react';
 import { isRangeField } from 'utils/recipe-field-checkers';
 import { getItemButtons } from '../form-buttons';
-import { getFormFieldsSchema } from '../form-group';
 import FormItem from '../form-item';
 import { renderRangeFormGroup } from './range';
 
@@ -16,7 +15,7 @@ export const renderServesFormGroup = (
 	key: string,
 	dispatcher: Dispatch<ActionType>,
 ) => {
-	const formFieldsSchema = getFormFieldsSchema(formItems, schema);
+	const formFieldsSchema = servesSchema;
 	const formItemAddId =
 		key.slice(0, -1) + (parseInt(key.slice(-1)) + 1).toString();
 	const formItemRemoveId = key;

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -10,7 +10,8 @@ interface DataPreviewProps {
 }
 
 const prettifyNumber = (num: number): string => {
-	if (num % 1 === 0) {
+	if (!num) return '';
+	else if (num % 1 === 0) {
 		return num.toString();
 	} else {
 		switch (num) {

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -42,6 +42,7 @@ const prettifyNumber = (num: number): string => {
 };
 
 const prettifyRange = (amount: Range) => {
+	if (!amount) return '';
 	return amount.min === amount.max
 		? prettifyNumber(amount.min)
 		: `${amount.min}-${amount.max}`;

--- a/recipes-client/consts/index.ts
+++ b/recipes-client/consts/index.ts
@@ -92,7 +92,7 @@ export const UIschema: UIschemaItem = {
 	serves: {
 		'ui:display': true,
 		'ui:locked': false,
-		'ui:removable': false,
+		'ui:removable': true,
 		'ui:order': ['amount', 'unit'],
 		amount: {
 			'ui:display': true,
@@ -101,6 +101,11 @@ export const UIschema: UIschemaItem = {
 			'ui:order': ['min', 'max'],
 		},
 		unit: {
+			'ui:display': true,
+			'ui:locked': false,
+			'ui:removable': false,
+		},
+		text: {
 			'ui:display': true,
 			'ui:locked': false,
 			'ui:removable': false,

--- a/recipes-client/interfaces/nastyHardcodedSchemas.tsx
+++ b/recipes-client/interfaces/nastyHardcodedSchemas.tsx
@@ -55,3 +55,20 @@ export const methodStepSchema = {
 		},
 	},
 };
+
+export const servesSchema = {
+	amount: {
+		min: {
+			type: 'integer',
+		},
+		max: {
+			type: 'integer',
+		},
+	},
+	unit: {
+		type: 'string',
+	},
+	text: {
+		type: 'string',
+	},
+};


### PR DESCRIPTION
Like #75 and #80, this addresses an issue where servings couldn't be added if there wasn't at least one in the dataset. 

Now there are buttons that just plop one on the end.

<img width="832" alt="image" src="https://github.com/guardian/recipes/assets/11380557/3595e481-44b5-49ab-80ff-3d7acd16d0ea">

Based on feedback from Anna B the unit input has been changed from a dropdown of preset 'people' or 'units' options to accommodate more nuanced information (like 20 'small cupcakes' or 1 '20cm cake', etc.)