### PR TITLE
Display recipe edit status in dashboard

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -596,7 +596,7 @@ class ApiController (
 
     def scanRequest(tableName: String) = new ScanRequest()
         .withTableName(tableName)
-        .withProjectionExpression("%s, title, contributors, canonicalArticle, isAppReady".format(partition_alias))
+        .withProjectionExpression("%s, title, contributors, byline, canonicalArticle, isAppReady".format(partition_alias))
         .withExpressionAttributeNames(expressionAttributeValues);
 
     val rawResult = dbClient.scan(scanRequest( config.rawRecipesTableName ));

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -607,6 +607,16 @@ class ApiController (
 
     val combinedData = rawResultData.filter( i => !curatedResultData.exists( _.getString(config.hashKey) == i.getString(config.hashKey) ) ) ++ curatedResultData
 
+    combinedData.foreach( i => {
+      val id = i.getString(config.hashKey)
+      val isInCuratedTable = if (curatedResultData.exists( _.getString(config.hashKey) == id )) {
+        true
+      } else {
+        false
+      }
+      i.withBoolean("isInCuratedTable", isInCuratedTable)
+    })
+
       val response = Json.toJson(combinedData.map(
         i => Json.parse(i.toJSON())
       ))

--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -2,7 +2,7 @@
 import { css } from '@emotion/react';
 import { SvgExternal } from '@guardian/source-react-components';
 import { curationEndpoint } from '../../consts/index';
-import { AppReadyStatus } from '../reusables/app-ready-status';
+import { CheckedSymbol } from '../reusables/app-ready-status';
 
 interface RecipeListProps {
 	list: RecipeListType[];
@@ -14,14 +14,16 @@ export interface RecipeListType {
 	contributors: string[];
 	canonicalArticle: string;
 	isAppReady: boolean;
+	isInCuratedTable: boolean;
 }
 
 const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 	return (
 		<table css={tableStyles}>
 			<colgroup>
-				<col style={{ width: '60%' }} />
+				<col style={{ width: '50%' }} />
 				<col style={{ width: '20%' }} />
+				<col style={{ width: '10%' }} />
 				<col style={{ width: '10%' }} />
 				<col style={{ width: '10%' }} />
 			</colgroup>
@@ -29,13 +31,24 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 				<tr>
 					<th>Recipe</th>
 					<th>Author(s)</th>
+					<th>Edited</th>
 					<th>App-ready</th>
 					<th>Actions</th>
 				</tr>
 			</thead>
 			<tbody>
 				{list.map(
-					({ id, title, contributors, canonicalArticle, isAppReady }, i) => {
+					(
+						{
+							id,
+							title,
+							contributors,
+							canonicalArticle,
+							isAppReady,
+							isInCuratedTable,
+						},
+						i,
+					) => {
 						return (
 							<tr key={`row_${i}`}>
 								<td key={`path_${i}_title`}>
@@ -48,8 +61,11 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 									</a>
 								</td>
 								<td key={`path_${i}_author`}> {contributors.join(', ')} </td>
+								<td key={`path_${i}_edited`}>
+									<CheckedSymbol isAppReady={isInCuratedTable} />
+								</td>
 								<td key={`path_${i}_app`}>
-									<AppReadyStatus isAppReady={isAppReady} />
+									<CheckedSymbol isAppReady={isAppReady} />
 								</td>
 								<td key={`path_${i}_links`}>
 									<a href={curationEndpoint + '/' + id}>Edit</a>

--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -12,12 +12,37 @@ export interface RecipeListType {
 	id: string;
 	title: string;
 	contributors: string[];
+	byline: string[];
 	canonicalArticle: string;
 	isAppReady: boolean;
 	isInCuratedTable: boolean;
 }
 
 const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
+	const displayAuthor = (contributors: string[], byline: string[]) => {
+		const prettifyContributorId = (contributorId: string) => {
+			if (contributorId === 'profile/yotamottolenghi') {
+				return 'Yotam Ottolenghi';
+			}
+			if (contributorId === 'profile/nigelslater') {
+				return 'Nigel Slater';
+			}
+			return contributorId
+				.split('/')
+				.pop()
+				.split('-')
+				.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+				.join(' ');
+		};
+		contributors = contributors.map(prettifyContributorId);
+		if (contributors.length > 0) {
+			return contributors.map((c) => prettifyContributorId(c)).join(', ');
+		} else if (byline.length > 0) {
+			return byline.join(', ');
+		} else {
+			return '-';
+		}
+	};
 	return (
 		<table css={tableStyles}>
 			<colgroup>
@@ -43,6 +68,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 							id,
 							title,
 							contributors,
+							byline,
 							canonicalArticle,
 							isAppReady,
 							isInCuratedTable,
@@ -60,7 +86,9 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 										<SvgExternal isAnnouncedByScreenReader size="xsmall" />
 									</a>
 								</td>
-								<td key={`path_${i}_author`}> {contributors.join(', ')} </td>
+								<td key={`path_${i}_author`}>
+									{displayAuthor(contributors, byline)}{' '}
+								</td>
 								<td key={`path_${i}_edited`}>
 									<CheckedSymbol isAppReady={isInCuratedTable} />
 								</td>

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { AllRecipeFields, Ingredient } from 'interfaces/main';
 import { css } from '@emotion/react';
-import { AppReadyStatus } from '../reusables/app-ready-status';
+import { CheckedSymbol } from '../reusables/app-ready-status';
 import { Range } from 'interfaces/main';
 import { palette } from '@guardian/source-foundations';
 
@@ -79,7 +79,7 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 			<div>
 				<small>Marked app-ready</small>
 				<div>
-					<AppReadyStatus isAppReady={recipeData.isAppReady} />
+					<CheckedSymbol isAppReady={recipeData.isAppReady} />
 				</div>
 			</div>
 			<div>

--- a/recipes-client/components/reusables/app-ready-status.tsx
+++ b/recipes-client/components/reusables/app-ready-status.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 
-export const AppReadyStatus = ({ isAppReady }: { isAppReady: boolean }) => {
+export const CheckedSymbol = ({ isAppReady }: { isAppReady: boolean }) => {
 	{
 		return isAppReady ? (
 			<span css={tickStyles}>

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -14,15 +14,17 @@ const Home = (): JSX.Element => {
 		[],
 	);
 	const [listFilter, setListFilter] = useState<
-		'all' | 'curated' | 'non-curated'
+		'all' | 'app-ready' | 'edited-but-not-app-ready' | 'non-curated'
 	>('all');
 
 	useEffect(() => {
 		const recipes = recipeList.filter((recipe) => {
 			if (listFilter === 'all') {
 				return true;
-			} else if (listFilter === 'curated') {
+			} else if (listFilter === 'app-ready') {
 				return recipe.isAppReady;
+			} else if (listFilter === 'edited-but-not-app-ready') {
+				return !recipe.isAppReady && recipe.isInCuratedTable;
 			} else if (listFilter === 'non-curated') {
 				return !recipe.isAppReady;
 			} else {
@@ -91,10 +93,17 @@ const Home = (): JSX.Element => {
 					/>
 					<Radio
 						name="filter"
-						value="curated"
-						label="Curated"
-						onChange={() => setListFilter('curated')}
-						checked={listFilter === 'curated'}
+						value="app-ready"
+						label="App-approved"
+						onChange={() => setListFilter('app-ready')}
+						checked={listFilter === 'app-ready'}
+					/>
+					<Radio
+						name="filter"
+						value="edited-but-not-app-ready"
+						label="Edited but not app-approved"
+						onChange={() => setListFilter('edited-but-not-app-ready')}
+						checked={listFilter === 'edited-but-not-app-ready'}
 					/>
 					<Radio
 						name="filter"


### PR DESCRIPTION
Following feedback from Anna B we wanted to provide more differentiation on recipe status than a binary app-ready/not app-ready, so that curators can keep track of recipes they've edited but aren't ready to go into the app.

To that end this PR adds an `isInCuratedTable` field to the /list endpoint, which means we can display when a recipe has been edited (i.e. saved to the curated DynamoDB table) but not yet marked app-ready.

<img width="1721" alt="image" src="https://github.com/guardian/recipes/assets/11380557/f045150c-3f67-4500-8c0e-1d114f743e6e">

I've updated the dashboard filtering accordingly so users can quickly isolate in progress recipes. 

I've also taken the opportunity to tidy up what's displayed in the 'Author(s)' column. Since we shifted to contributor tags we've been displaying them, and nothing at all if the field is empty:

<img width="1722" alt="image" src="https://github.com/guardian/recipes/assets/11380557/07107d99-5ca0-409b-b9df-06ac45a4573e">

Now we pull through both contributor and byline info and fall back to the latter if the first is empty. There's also a ham fisted script that converts contributor tags into something more readable. 