### PR TITLE
Fix 'Awaiting curation' homepage filter conditions

### DIFF
--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -26,7 +26,7 @@ const Home = (): JSX.Element => {
 			} else if (listFilter === 'edited-but-not-app-ready') {
 				return !recipe.isAppReady && recipe.isInCuratedTable;
 			} else if (listFilter === 'non-curated') {
-				return !recipe.isAppReady;
+				return !recipe.isAppReady && !recipe.isInCuratedTable;
 			} else {
 				console.error('Invalid filter');
 				return true;


### PR DESCRIPTION
Adds a logic change I missed in #83. This creates the desired behaviour of displaying recipes that have not been marked app-ready and do not appear in the curated table (the latter should be enough but no harm in checking both)