### PR TITLE
Make dropdowns empty as default

### DIFF
--- a/recipes-client/components/form/form-item.tsx
+++ b/recipes-client/components/form/form-item.tsx
@@ -129,7 +129,7 @@ const renderInput = (
 		);
 	} else {
 		const choices_ = choices.slice().sort((a, b) => a.localeCompare(b));
-		// choices_.unshift('');
+		choices_.unshift('');
 		return (
 			<>
 				<select


### PR DESCRIPTION
This restores behaviour in form dropdown fields where the field is empty when generated. As flagged by editorial there have been instances where the first field happens to display the desired input but because it's not being selected explicitly that wasn't translating to the data.

<img width="331" alt="image" src="https://github.com/guardian/recipes/assets/11380557/38958ae3-56fa-4637-befd-e6a61c09cb8d">

By putting an empty string at the front of the list of options users have to explicitly select values.