### PR TITLE
Enable adding a new ingredient without specifying amount

### DIFF
--- a/recipes-client/reducers/recipe-reducer.tsx
+++ b/recipes-client/reducers/recipe-reducer.tsx
@@ -153,9 +153,9 @@ function Entries2Object(
 	// Helper function to replace `Object.fromEntries(arr)`
 	return [...arr].reduce((obj: Record<string, unknown>, [key, val]) => {
 		if (key == 'min' || key == 'max') {
-      return null;
-    }
-    if (typeof key === 'string') {
+			return null;
+		}
+		if (typeof key === 'string') {
 			obj[key] = val;
 			return obj;
 		}


### PR DESCRIPTION
Display 'add amount' button when a new ingredient row is added (instead of defaulting min 1 and max 1) so that unspecified amount can still be entered

before
![image](https://github.com/guardian/recipes/assets/47318984/9793a68b-9a12-4290-a031-30b3472ee7ba)


after
![image](https://github.com/guardian/recipes/assets/47318984/6d30aed0-75b7-4749-88ba-63a56462b263)
