### PR TITLE
More serving dropdown options

### DIFF
--- a/recipes-client/components/form/inputs/timings.tsx
+++ b/recipes-client/components/form/inputs/timings.tsx
@@ -29,7 +29,16 @@ export const renderTimingsFormGroup = (
 			<FormItem
 				text={formItems[k]}
 				choices={
-					k === 'qualifier' ? ['prep-time', 'cook-time', 'set-time'] : null
+					k === 'qualifier'
+						? [
+								'prep-time',
+								'cook-time',
+								'set-time',
+								'marinate-time',
+								'soak-time',
+								'chill-time',
+						  ]
+						: null
 				}
 				label={`${key}.${k}`}
 				key={`${key}.${k}`}


### PR DESCRIPTION
Following on from #85 this adds a few more timing qualifier options.

<img width="668" alt="image" src="https://github.com/guardian/recipes/assets/11380557/e43cf5af-f668-4c1e-bebc-27da4a74bf96">
