### PR TITLE
Mini data dashboard summary of curated recipes

### DIFF
--- a/recipes-client/components/dashboard/recipes-overview.tsx
+++ b/recipes-client/components/dashboard/recipes-overview.tsx
@@ -1,0 +1,53 @@
+import { RecipeListType } from './recipe-list';
+
+interface RecipesOverviewProps {
+	recipesList: RecipeListType[];
+}
+
+export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
+	const appReadyRecipes = recipesList.filter((recipe) => recipe.isAppReady);
+
+	const chefs = [
+		{
+			name: 'Felicity Cloake',
+			contributorTag: 'profile/felicity-cloake',
+		},
+		{
+			name: 'Yotam Ottolenghi',
+			contributorTag: 'profile/yotamottolenghi',
+		},
+		{
+			name: 'Nigel Slater',
+			contributorTag: 'profile/nigelslater',
+		},
+		{
+			name: 'Meera Sodha',
+			contributorTag: 'profile/meera-sodha',
+		},
+	];
+
+	const getAuthorCount = (contributorTag: string) => {
+		return appReadyRecipes.reduce(
+			(acc, recipe) =>
+				recipe.contributors.includes(contributorTag) ? ++acc : acc,
+			0,
+		);
+	};
+	const authorSummaryCard = (name: string, contributorTag: string) => {
+		const count = getAuthorCount(contributorTag);
+		const percentageOfAllRecipes = (count / appReadyRecipes.length) * 100;
+		return (
+			<>
+				<div>
+					{name}: {getAuthorCount(contributorTag)} ({percentageOfAllRecipes}%)
+				</div>
+			</>
+		);
+	};
+	return (
+		<>
+			<h2>{appReadyRecipes.length} app-ready recipes</h2>
+			{chefs.map((chef) => authorSummaryCard(chef.name, chef.contributorTag))}
+		</>
+	);
+};

--- a/recipes-client/components/dashboard/recipes-overview.tsx
+++ b/recipes-client/components/dashboard/recipes-overview.tsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
 import { RecipeListType } from './recipe-list';
 
 interface RecipesOverviewProps {
@@ -24,30 +26,96 @@ export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
 			name: 'Meera Sodha',
 			contributorTag: 'profile/meera-sodha',
 		},
+		{
+			name: 'Anna Jones',
+			contributorTag: 'profile/anna-jones',
+		},
+		{
+			name: 'Thomasina Miers',
+			contributorTag: 'profile/thomasina-miers',
+		},
+		{
+			name: 'Nigella Lawson',
+			contributorTag: 'profile/nigella-lawson',
+		},
+		{
+			name: 'Rachel Roddy',
+			contributorTag: 'profile/rachel-roddy',
+		},
+		{
+			name: 'Benjamina Ebuehi',
+			contributorTag: 'profile/benjamina-ebuehi',
+		},
+		{
+			name: 'Ravneet Gill',
+			contributorTag: 'profile/ravneet-gill',
+		},
+		{
+			name: 'Jose Pizarro',
+			contributorTag: 'profile/jose-pizarro',
+		},
+		{
+			name: 'Rukmini Iyer',
+			contributorTag: 'profile/rukmini-iyer',
+		},
 	];
 
-	const getAuthorCount = (contributorTag: string) => {
-		return appReadyRecipes.reduce(
+	const countOfRecipesByOtherChefs = appReadyRecipes.reduce(
+		(acc, recipe) =>
+			recipe.contributors.some(
+				(contributor) =>
+					!chefs.map((chef) => chef.contributorTag).includes(contributor),
+			)
+				? ++acc
+				: acc,
+		0,
+	);
+	const authorSummaryCard = (name: string, contributorTag: string) => {
+		const chefRecipeCount = appReadyRecipes.reduce(
 			(acc, recipe) =>
 				recipe.contributors.includes(contributorTag) ? ++acc : acc,
 			0,
 		);
-	};
-	const authorSummaryCard = (name: string, contributorTag: string) => {
-		const count = getAuthorCount(contributorTag);
-		const percentageOfAllRecipes = (count / appReadyRecipes.length) * 100;
+		const percentOfAllRecipes = Math.round(
+			(chefRecipeCount / appReadyRecipes.length) * 100,
+		);
 		return (
-			<>
-				<div>
-					{name}: {getAuthorCount(contributorTag)} ({percentageOfAllRecipes}%)
-				</div>
-			</>
+			<div css={infoBoxStyles}>
+				<strong>{name}:</strong> {chefRecipeCount} ({percentOfAllRecipes}%)
+			</div>
 		);
 	};
 	return (
 		<>
-			<h2>{appReadyRecipes.length} app-ready recipes</h2>
-			{chefs.map((chef) => authorSummaryCard(chef.name, chef.contributorTag))}
+			<h3>
+				{appReadyRecipes.length} app-approved recipes, which break down as
+				follows...
+			</h3>
+			<div
+				css={css`
+					display: flex;
+					flex-direction: row;
+					flex-wrap: wrap;
+				`}
+			>
+				{chefs.map((chef) => authorSummaryCard(chef.name, chef.contributorTag))}
+				<div css={infoBoxStyles}>
+					<strong>Other chefs:</strong> {countOfRecipesByOtherChefs} (
+					{Math.round(
+						(countOfRecipesByOtherChefs / appReadyRecipes.length) * 100,
+					)}
+					%)
+				</div>
+			</div>
 		</>
 	);
 };
+
+const infoBoxStyles = css`
+	padding: 10px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	margin-bottom: 10px;
+	margin-right: 10px;
+	max-width: 300px;
+`;

--- a/recipes-client/components/dashboard/recipes-overview.tsx
+++ b/recipes-client/components/dashboard/recipes-overview.tsx
@@ -6,10 +6,20 @@ interface RecipesOverviewProps {
 	recipesList: RecipeListType[];
 }
 
+interface Chef {
+	name: string;
+	contributorTag: string;
+}
+
+interface RichChef extends Chef {
+	recipeCount: number;
+	percentOfAllRecipes: number;
+}
+
 export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
 	const appReadyRecipes = recipesList.filter((recipe) => recipe.isAppReady);
 
-	const chefs = [
+	const chefs: Chef[] = [
 		{
 			name: 'Felicity Cloake',
 			contributorTag: 'profile/felicity-cloake',
@@ -60,6 +70,24 @@ export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
 		},
 	];
 
+	const richChefsObjectArray: RichChef[] = chefs
+		.map((chef) => {
+			const chefRecipeCount = appReadyRecipes.reduce(
+				(acc, recipe) =>
+					recipe.contributors.includes(chef.contributorTag) ? ++acc : acc,
+				0,
+			);
+			const percentOfAllRecipes = Math.round(
+				(chefRecipeCount / appReadyRecipes.length) * 100,
+			);
+			return {
+				...chef,
+				recipeCount: chefRecipeCount,
+				percentOfAllRecipes: percentOfAllRecipes,
+			};
+		})
+		.sort((a, b) => b.recipeCount - a.recipeCount)
+		.filter((chef) => chef.recipeCount > 0);
 	const countOfRecipesByOtherChefs = appReadyRecipes.reduce(
 		(acc, recipe) =>
 			recipe.contributors.some(
@@ -70,20 +98,15 @@ export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
 				: acc,
 		0,
 	);
-	const authorSummaryCard = (name: string, contributorTag: string) => {
-		const chefRecipeCount = appReadyRecipes.reduce(
-			(acc, recipe) =>
-				recipe.contributors.includes(contributorTag) ? ++acc : acc,
-			0,
-		);
-		const percentOfAllRecipes = Math.round(
-			(chefRecipeCount / appReadyRecipes.length) * 100,
-		);
-		return (
-			<div css={infoBoxStyles}>
-				<strong>{name}:</strong> {chefRecipeCount} ({percentOfAllRecipes}%)
-			</div>
-		);
+	const renderChefSummaryCards = (chefs: RichChef[]) => {
+		return chefs.map((chef) => {
+			return (
+				<div css={infoBoxStyles}>
+					<strong>{chef.name}:</strong> {chef.recipeCount} (
+					{chef.percentOfAllRecipes}%)
+				</div>
+			);
+		});
 	};
 	return (
 		<>
@@ -98,7 +121,7 @@ export const RecipesOverview = ({ recipesList }: RecipesOverviewProps) => {
 					flex-wrap: wrap;
 				`}
 			>
-				{chefs.map((chef) => authorSummaryCard(chef.name, chef.contributorTag))}
+				{renderChefSummaryCards(richChefsObjectArray)}
 				<div css={infoBoxStyles}>
 					<strong>Other chefs:</strong> {countOfRecipesByOtherChefs} (
 					{Math.round(

--- a/recipes-client/components/dashboard/welcome-explainer.tsx
+++ b/recipes-client/components/dashboard/welcome-explainer.tsx
@@ -1,0 +1,22 @@
+export const WelcomeExplainer = () => {
+	return (
+		<div>
+			<h2>This is it how it works:</h2>
+			<ul>
+				<li>Pick a recipe.</li>
+				<li>Edit it.</li>
+				<li>Save it.</li>
+			</ul>
+			<div>
+				Read the{' '}
+				<a
+					href="https://docs.google.com/document/d/1wrVUX7vVTLBd0fxqDbQxqmyXoY4Vvyw5aX79tMxROhk/edit#heading=h.7n6l8nswve9p"
+					target="_blank"
+				>
+					recipe data curation guide
+				</a>{' '}
+				for a more in-depth breakdown.
+			</div>
+		</div>
+	);
+};

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -2,6 +2,7 @@
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
 import { Radio, RadioGroup } from '@guardian/source-react-components';
+import { RecipesOverview } from 'components/dashboard/recipes-overview';
 import { useEffect, useState } from 'react';
 import RecipeList, {
 	RecipeListType,
@@ -81,6 +82,7 @@ const Home = (): JSX.Element => {
 					for a more in-depth breakdown.
 				</div>
 			</div>
+			<RecipesOverview recipesList={recipeList} />
 			<hr />
 			<div>
 				<RadioGroup orientation="horizontal" label="Filter displayed recipes">

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -8,6 +8,7 @@ import RecipeList, {
 	RecipeListType,
 } from '../components/dashboard/recipe-list';
 import { listEndpoint } from '../consts/index';
+import { WelcomeExplainer } from 'components/dashboard/welcome-explainer';
 
 const Home = (): JSX.Element => {
 	const [recipeList, setList] = useState<RecipeListType[]>([]);
@@ -64,25 +65,28 @@ const Home = (): JSX.Element => {
 					app-approved recipes and counting
 				</div>
 			</div>
-			<div css={explainerStyles}>
-				<h2>This is it how it works:</h2>
-				<ul>
-					<li>Pick a recipe.</li>
-					<li>Edit it.</li>
-					<li>Save it.</li>
-				</ul>
-				<div>
-					Read the{' '}
-					<a
-						href="https://docs.google.com/document/d/1wrVUX7vVTLBd0fxqDbQxqmyXoY4Vvyw5aX79tMxROhk/edit#heading=h.7n6l8nswve9p"
-						target="_blank"
-					>
-						recipe data curation guide
-					</a>{' '}
-					for a more in-depth breakdown.
+			<div
+				css={css`
+					display: flex;
+					flex-direction: row;
+					justify-content: space-between;
+				`}
+			>
+				<div
+					css={css`
+						width: 33%;
+					`}
+				>
+					<WelcomeExplainer />
+				</div>
+				<div
+					css={css`
+						width: 67%;
+					`}
+				>
+					<RecipesOverview recipesList={recipeList} />
 				</div>
 			</div>
-			<RecipesOverview recipesList={recipeList} />
 			<hr />
 			<div>
 				<RadioGroup orientation="horizontal" label="Filter displayed recipes">
@@ -128,8 +132,4 @@ export default Home;
 
 const mainContainerStyles = css`
 	padding: 20px;
-`;
-
-const explainerStyles = css`
-	margin-bottom: 30px;
 `;


### PR DESCRIPTION
## What does this change?

This adds a modest summary of the curated data to the Hatch homepage. As a first pass it displays the number of app-ready recipes per top chef and what percentage of the overall count they are.

Screenshot below is of it running locally so the value isn't so clear but you get the gist:

<img width="1716" alt="image" src="https://github.com/guardian/recipes/assets/11380557/d8b16423-6c5b-4296-b5ae-b6d1b8f62a28">

The hope with this change is that editorial will have a birds-eye view of the curated data and can prioritise work / recipe structuring requests based on imbalances in the data.
