### PR TITLE
Adjust model and UI to shift `durationInMins` field from number to range

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -276,7 +276,19 @@ class ApiController (
                   ]
                 },
                 "durationInMins": {
-                  "type": "integer"
+                  "type": "object",
+                  "properties": {
+                              "min": {
+                                "type": "integer"
+                              },
+                              "max": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "min",
+                              "max"
+                            ]
                 },
                 "text": {
                   "type": "string"

--- a/recipes-client/components/form/form-buttons.tsx
+++ b/recipes-client/components/form/form-buttons.tsx
@@ -11,13 +11,7 @@ export const getItemButtons = (
 	formFieldsSchema: SchemaItem,
 	dispatcher: Dispatch<ActionType>,
 ): JSX.Element => {
-	if (key === 'timings') {
-		formFieldsSchema = formFieldsSchema.properties;
-	}
-	if (key === 'instructions') {
-		formFieldsSchema = formFieldsSchema.properties;
-	}
-	if (key === 'serves') {
+	if (key === 'instructions' || key === 'serves' || key === 'timings') {
 		formFieldsSchema = formFieldsSchema.properties;
 	}
 	return (
@@ -31,7 +25,7 @@ export const getItemButtons = (
 			/>
 			<FormButton
 				text={`Remove`}
-				buttonId={`${key}.add`}
+				buttonId={`${key}.remove`}
 				onClick={() => handleRemoveField(formItemRemoveLastId, dispatcher)}
 			/>
 		</div>

--- a/recipes-client/components/form/inputs/timings.tsx
+++ b/recipes-client/components/form/inputs/timings.tsx
@@ -4,63 +4,74 @@ import { Dispatch } from 'react';
 import { getItemButtons } from '../form-buttons';
 import { getFormFieldsSchema } from '../form-group';
 import FormItem from '../form-item';
+import { renderRangeFormGroup } from './range';
+import { isRangeField } from 'utils/recipe-field-checkers';
 
 export const renderTimingsFormGroup = (
-	formItems: Timing,
-	schema: SchemaItem,
-	choices: string[] | null,
-	key: string,
-	dispatcher: Dispatch<ActionType>,
+  formItems: Timing,
+  schema: SchemaItem,
+  choices: string[] | null,
+  key: string,
+  dispatcher: Dispatch<ActionType>,
 ) => {
-	const formFieldsSchema = getFormFieldsSchema(schema);
-	const formItemAddId =
-		key.slice(0, -1) + (parseInt(key.slice(-1)) + 1).toString();
-	const formItemRemoveId = key;
+  const formFieldsSchema = getFormFieldsSchema(schema);
+  const formItemAddId =
+    key.slice(0, -1) + (parseInt(key.slice(-1)) + 1).toString();
+  const formItemRemoveId = key;
 
-	const formItemButtons = getItemButtons(
-		key,
-		formItemAddId,
-		formItemRemoveId,
-		formFieldsSchema,
-		dispatcher,
-	);
-	const fields = Object.keys(formItems).map((k: keyof Timing) => {
-		return (
-			<FormItem
-				text={formItems[k]}
-				choices={
-					k === 'qualifier'
-						? [
-								'prep-time',
-								'cook-time',
-								'set-time',
-								'marinate-time',
-								'soak-time',
-								'chill-time',
-								'freeze-time',
-								'infuse-time',
-								'rest-time',
-								'prove-time',
-						  ]
-						: null
-				}
-				label={`${key}.${k}`}
-				key={`${key}.${k}`}
-				dispatcher={dispatcher}
-			/>
-		);
-	});
-	return [
-		<div
-			css={{
-				display: 'flex !important',
-				fontFamily: 'GuardianTextSans',
-				fontSize: '1.0625rem',
-				justifyContent: 'top',
-			}}
-		>
-			{fields} minutes
-			{formItemButtons}
-		</div>,
-	];
+  const formItemButtons = getItemButtons(
+    key,
+    formItemAddId,
+    formItemRemoveId,
+    formFieldsSchema,
+    dispatcher,
+  );
+  const fields = Object.keys(formItems).map((k: keyof Timing) => {
+    if (isRangeField(formItems[k])) {
+      return renderRangeFormGroup(
+        formItems[k],
+        choices,
+        `${key}.${k}`,
+        dispatcher,
+      );
+    } else {
+      return (
+        <FormItem
+          text={formItems[k]}
+          choices={
+            k === 'qualifier'
+              ? [
+                'prep-time',
+                'cook-time',
+                'set-time',
+                'marinate-time',
+                'soak-time',
+                'chill-time',
+                'freeze-time',
+                'infuse-time',
+                'rest-time',
+                'prove-time',
+              ]
+              : null
+          }
+          label={`${key}.${k}`}
+          key={`${key}.${k}`}
+          dispatcher={dispatcher}
+        />
+      );
+    }
+  });
+  return [
+    <div
+      css={{
+        display: 'flex !important',
+        fontFamily: 'GuardianTextSans',
+        fontSize: '1.0625rem',
+        justifyContent: 'top',
+      }}
+    >
+      {fields} minutes
+      {formItemButtons}
+    </div>,
+  ];
 };

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -48,10 +48,37 @@ const prettifyRange = (amount: Range) => {
 		: `${amount.min}-${amount.max}`;
 };
 
-const prettifyDurationInMins = (durationInMins: number): string => {
-	const hours = Math.floor(durationInMins / 60);
-	const mins = durationInMins % 60;
-	return `${hours > 0 ? `${hours}h` : ''} ${mins > 0 ? `${mins}m` : ''}`;
+const prettifyDurationInMins = (durationInMins: number | Range): string => {
+	if (!durationInMins) return '';
+	if (typeof durationInMins === 'number') {
+		const hours = Math.floor(durationInMins / 60);
+		const mins = durationInMins % 60;
+		return `${hours > 0 ? `${hours}h` : ''} ${mins > 0 ? `${mins}m` : ''}`;
+	} else {
+		const min = durationInMins.min;
+		const max = durationInMins.max;
+		if (min === max) {
+			const hours = Math.floor(min / 60);
+			const mins = min % 60;
+			return `${hours > 0 ? `${hours}h` : ''} ${mins > 0 ? `${mins}m` : ''}`;
+		}
+		const minHours = Math.floor(min / 60);
+		const minMins = min % 60;
+		const maxHours = Math.floor(max / 60);
+		const maxMins = max % 60;
+		if (minHours === 0 && maxHours === 0) {
+			return `${minMins} - ${maxMins}m`;
+		}
+		if (minHours > 0 && maxHours > 0) {
+			return `${minHours}h${minMins > 0 ? `${minMins}m` : ''} - ${maxHours}h${
+				maxMins > 0 ? `${maxMins}m` : ''
+			}`;
+		}
+		if (minHours === 0 && maxHours > 0) {
+			return `${minMins} - ${maxHours}h ${maxMins > 0 ? `${maxMins}m` : ''}`;
+		}
+		return `${min}m - ${max}m`;
+	}
 };
 
 export const DataPreview = ({ recipeData }: DataPreviewProps) => {
@@ -91,7 +118,10 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 			<div>
 				<small>Canonical article</small>
 				<div>
-					<a href={recipeData.canonicalArticle} target="_blank">
+					<a
+						href={`https://theguardian.com/${recipeData.canonicalArticle}`}
+						target="_blank"
+					>
 						{recipeData.canonicalArticle}
 					</a>
 				</div>

--- a/recipes-client/consts/index.ts
+++ b/recipes-client/consts/index.ts
@@ -115,6 +115,7 @@ export const UIschema: UIschemaItem = {
 			'ui:display': true,
 			'ui:locked': false,
 			'ui:removable': true,
+			'ui:order': ['min', 'max'],
 		},
 	},
 	instructions: {

--- a/recipes-client/interfaces/main.tsx
+++ b/recipes-client/interfaces/main.tsx
@@ -131,7 +131,7 @@ export interface Ingredient {
 
 export type Timing = {
 	qualifier: string; // e.g. 'passive', 'active', 'set', 'chill'
-	durationInMins: number;
+	durationInMins: Range;
 	text?: string; // Original text
 };
 

--- a/recipes-client/reducers/recipe-reducer.tsx
+++ b/recipes-client/reducers/recipe-reducer.tsx
@@ -144,6 +144,9 @@ const getSchemaItem = (
 			if (key === 'images') {
 				return [key, null];
 			}
+			if (key === 'durationInMins') {
+				return [key, { min: 0, max: 0 }];
+			}
 			return [key, getSchemaItem(schemaI[key])];
 		}, []);
 		return entriesToObject(outputArray);


### PR DESCRIPTION
## What does this change?

This updates the recipe data model to expect ranges rather than numbers in the timings `durationInMins` field, and adds an under the hood conversion check as part of Hatch's save functionality.

## How to test

Run locally, save recipes, and see if the duration field shape changes and saves as expected.

## How can we measure success?

Recipe data model is consistent all through the D&I -> Hatch -> CoPip -> App pipeline.

## Have we considered potential risks?

As ever there is a wariness about messing with data integrity. Between nightly backups and strict type checking on anything going into DynamoDB hopefully we're safe here.
