### PR TITLE
Adjust what 'Edited' means in homepage dashboard

### DIFF
--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -15,7 +15,7 @@ export interface RecipeListType {
 	byline: string[];
 	canonicalArticle: string;
 	isAppReady: boolean;
-	isInCuratedTable: boolean;
+	hasBeenEdited: boolean;
 }
 
 const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
@@ -71,7 +71,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 							byline,
 							canonicalArticle,
 							isAppReady,
-							isInCuratedTable,
+							hasBeenEdited,
 						},
 						i,
 					) => {
@@ -90,7 +90,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 									{displayAuthor(contributors, byline)}{' '}
 								</td>
 								<td key={`path_${i}_edited`}>
-									<CheckedSymbol isAppReady={isInCuratedTable} />
+									<CheckedSymbol isAppReady={hasBeenEdited} />
 								</td>
 								<td key={`path_${i}_app`}>
 									<CheckedSymbol isAppReady={isAppReady} />

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -24,9 +24,9 @@ const Home = (): JSX.Element => {
 			} else if (listFilter === 'app-ready') {
 				return recipe.isAppReady;
 			} else if (listFilter === 'edited-but-not-app-ready') {
-				return !recipe.isAppReady && recipe.isInCuratedTable;
+				return !recipe.isAppReady && recipe.hasBeenEdited;
 			} else if (listFilter === 'non-curated') {
-				return !recipe.isAppReady && !recipe.isInCuratedTable;
+				return !recipe.isAppReady && !recipe.hasBeenEdited;
 			} else {
 				console.error('Invalid filter');
 				return true;


### PR DESCRIPTION
This changes the logic behind recipes being 'Edited'. Before it meant the recipe appeared in the curated database, now it means the description field in the raw and curated version are different. Feels a smidge hacky but should be more useful to editorial