### PR TITLE
Grid integration

### DIFF
--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -3,8 +3,10 @@ import { css } from '@emotion/react';
 import { ImageObject } from 'interfaces/main';
 import React, { useEffect, useState } from 'react';
 
-// TODO: Vary based on stage
-const gridOrigin = 'https://media.test.dev-gutools.co.uk';
+const gridTopLevelDomain = window.location.hostname.includes('.gutools.co.uk')
+	? 'gutools.co.uk'
+	: 'test.dev-gutools.co.uk';
+const gridOrigin = `https://media.${gridTopLevelDomain}`;
 
 type WithGridSelectorProps = React.PropsWithChildren<{
 	callback: (chosenImage: ImageObject) => void;
@@ -68,15 +70,13 @@ export const WithGridSelector = ({
 		return () => window.removeEventListener('message', handleGridMessage); // Cleanup/unmount function
 	}, []);
 
-	const start = (
-		startingUrl: string = `${gridOrigin}/?cropType=all`,
-	) => {
+	const start = (startingUrl: string = `${gridOrigin}/?cropType=all`) => {
 		const url = new URL(startingUrl);
 		const maybeCropId = url.searchParams.get('crop');
 		if (maybeCropId) {
 			handleSelectedCrop(
 				maybeCropId,
-				`https://api.${url.hostname}/${url.pathname}`
+				`https://api.${url.hostname}/${url.pathname}`,
 			);
 		} else {
 			setMaybeIframeUrl(startingUrl);

--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
+import { apiURL } from 'consts';
+import { ImageObject } from 'interfaces/main';
+import React from 'react';
+import { useEffect, useState } from 'react';
+
+// TODO: Vary based on stage
+const gridOrigin = 'https://media.test.dev-gutools.co.uk';
+
+export const isValidGridUrl = (url: string): boolean => {
+	return url.startsWith(gridOrigin);
+};
+
+const isValidCropUrl = (url: string): boolean => {
+	return url.startsWith(gridOrigin) && new URL(url).searchParams.has('crop');
+};
+
+export const useGridSelector = (): [
+	JSX.Element | null,
+	(startingUrl?: string) => Promise<ImageObject | null>,
+] => {
+	const [iframeStartingUrl, setIframeStartingUrl] = useState<string>(
+		`${gridOrigin}/?cropType=all`,
+	);
+	const [promiseResolveFn, setPromiseResolveFn] = useState<
+		((value: ImageObject | null) => void) | null
+	>(null);
+	useEffect(() => {
+		if (!promiseResolveFn) return;
+		const handleSelectedCrop = async (event: MessageEvent) => {
+			if (event.origin !== gridOrigin) return;
+			const { data } = event;
+			const cropId = data?.crop.data.id;
+			const mediaApiUri = data?.image.uri;
+			const { data: imageData } = (await (
+				await fetch(mediaApiUri, {
+					credentials: 'include',
+				})
+			).json()) as {
+				data: {
+					exports: {
+						id: string;
+						assets: { dimensions: { width: number }; file: string }[];
+						master: { file: string };
+					}[];
+					id: string;
+					metadata: { credit: string; description: string };
+				};
+			};
+			const cropExport = imageData.exports.find((crop) => crop.id === cropId)!;
+			const preferredAsset =
+				cropExport.assets.find((asset) => asset.dimensions.width === 1000) ||
+				cropExport.assets.find((asset) => asset.dimensions.width === 500) ||
+				cropExport.master;
+			const imageObject: ImageObject = {
+				url: preferredAsset.file,
+				mediaId: imageData.id,
+				cropId,
+				source: imageData.metadata.credit,
+				// photographer: string | undefined;
+				// imageType: string | undefined;
+				caption: imageData.metadata.description,
+				mediaApiUri,
+			};
+			promiseResolveFn(imageObject);
+			setPromiseResolveFn(null);
+			// TODO: Support dragging and dropping images into Hatch
+			// TODO: Make iframe path based on dropped URL
+			// TODO: Shortcut to fetch step if crop URL dropped
+		};
+		window.addEventListener('message', handleSelectedCrop);
+		return () => window.removeEventListener('message', handleSelectedCrop); // Cleanup/unmount function
+	}, [promiseResolveFn]);
+	const maybeElement = promiseResolveFn && (
+		<div
+			css={css`
+				background-color: rgba(0, 0, 0, 0.5);
+				position: fixed;
+				bottom: 0;
+				top: 0;
+				left: 0;
+				right: 0;
+				z-index: 999999;
+			`}
+		>
+			<button
+				onClick={() => {
+					promiseResolveFn(null);
+					setPromiseResolveFn(null);
+				}}
+				css={css`
+					position: absolute;
+					top: 40px;
+					right: 40px;
+				`}
+			>
+				Close
+			</button>
+			<iframe
+				src={iframeStartingUrl}
+				css={css`
+					width: calc(100% - 100px);
+					height: calc(100vh - 100px);
+					display: block;
+					margin: 50px;
+				`}
+			/>
+		</div>
+	);
+	const callback = (startingUrl?: string) =>
+		new Promise<ImageObject>((resolve) => {
+			setIframeStartingUrl(startingUrl || `${gridOrigin}/?cropType=all`);
+			// must use the function overload of setState here, to avoid resolve being invoked immediately
+			setPromiseResolveFn(() => resolve);
+		});
+	return [maybeElement, callback];
+};

--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -68,11 +68,19 @@ export const WithGridSelector = ({
 		return () => window.removeEventListener('message', handleGridMessage); // Cleanup/unmount function
 	}, []);
 
-	const displayGridPicker = (
+	const start = (
 		startingUrl: string = `${gridOrigin}/?cropType=all`,
 	) => {
-		// TODO: Shortcut to handleSelectedCrop if crop URL dropped -- url.startsWith(gridOrigin) && new URL(url).searchParams.get('crop');
-		setMaybeIframeUrl(startingUrl);
+		const url = new URL(startingUrl);
+		const maybeCropId = url.searchParams.get('crop');
+		if (maybeCropId) {
+			handleSelectedCrop(
+				maybeCropId,
+				`https://api.${url.hostname}/${url.pathname}`
+			);
+		} else {
+			setMaybeIframeUrl(startingUrl);
+		}
 	};
 
 	return (
@@ -90,13 +98,13 @@ export const WithGridSelector = ({
 			onDragOver={(e) => e.preventDefault()}
 			onDrop={(e) => {
 				e.preventDefault();
-				displayGridPicker(e.dataTransfer.getData('URL'));
+				start(e.dataTransfer.getData('URL'));
 				setIsDropTarget(false);
 			}}
 		>
 			{children}
 			<button
-				onClick={() => displayGridPicker()}
+				onClick={() => start()}
 				css={css`
 					font-size: 40px;
 				`}

--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -35,8 +35,8 @@ export const WithGridSelector = ({
 			data: {
 				exports: {
 					id: string;
-					assets: { dimensions: { width: number }; file: string }[];
-					master: { file: string };
+					assets: { dimensions: { width: number }; secureUrl: string }[];
+					master: { secureUrl: string };
 				}[];
 				id: string;
 				metadata: { credit: string; description: string; byline: string };
@@ -48,7 +48,7 @@ export const WithGridSelector = ({
 			cropExport.assets.find((asset) => asset.dimensions.width === 500) ||
 			cropExport.master;
 		const imageObject: ImageObject = {
-			url: preferredAsset.file,
+			url: preferredAsset.secureUrl,
 			mediaId: data.id,
 			cropId,
 			source: data.metadata.credit,

--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -39,7 +39,7 @@ export const WithGridSelector = ({
 					master: { file: string };
 				}[];
 				id: string;
-				metadata: { credit: string; description: string };
+				metadata: { credit: string; description: string; byline: string };
 			};
 		};
 		const cropExport = data.exports.find((crop) => crop.id === cropId)!;
@@ -52,7 +52,7 @@ export const WithGridSelector = ({
 			mediaId: data.id,
 			cropId,
 			source: data.metadata.credit,
-			// photographer: string | undefined; //TODO extract photographer from media-api response
+			photographer: data.metadata.byline,
 			// imageType: string | undefined; //TODO extract imageType from media-api response
 			caption: data.metadata.description,
 			mediaApiUri,

--- a/recipes-client/components/curation/grid-selector.tsx
+++ b/recipes-client/components/curation/grid-selector.tsx
@@ -107,6 +107,7 @@ export const WithGridSelector = ({
 				onClick={() => start()}
 				css={css`
 					font-size: 40px;
+					display: block;
 				`}
 			>
 				➕

--- a/recipes-client/components/form/form-group.tsx
+++ b/recipes-client/components/form/form-group.tsx
@@ -195,7 +195,9 @@ export const FormGroup = ({
 	const key = key_ || title;
 	const formDispatcher = dispatcher || null;
 
-	const [instructionsToMerge, setInstructionsToMerge] = useState<ModifiedInstruction[]>([]);
+	const [instructionsToMerge, setInstructionsToMerge] = useState<
+		ModifiedInstruction[]
+	>([]);
 	const [checkedFields, setCheckedFields] = useState({});
 
 	const toggleInstructionsToMerge = (
@@ -208,14 +210,18 @@ export const FormGroup = ({
 			objId: key,
 		};
 		if (e?.target.checked) {
-			setInstructionsToMerge((instructions) => [...instructions, modifiedInstruction]);
+			setInstructionsToMerge((instructions) => [
+				...instructions,
+				modifiedInstruction,
+			]);
 		} else {
 			setInstructionsToMerge((instructions) =>
-				instructions.filter((instruction) => instruction.objId !== modifiedInstruction.objId),
+				instructions.filter(
+					(instruction) => instruction.objId !== modifiedInstruction.objId,
+				),
 			);
 		}
 	};
-
 
 	// Set up form group
 	const rComponents =
@@ -262,7 +268,7 @@ export const FormGroup = ({
 
 		setInstructionsToMerge([]);
 
-    // De-select checkboxes previously selected after the merge
+		// De-select checkboxes previously selected after the merge
 		const resetCheckedFields = { ...checkedFields };
 		Object.keys(resetCheckedFields).forEach((key) => {
 			resetCheckedFields[key] = false;
@@ -278,15 +284,18 @@ export const FormGroup = ({
 					type="button"
 					onClick={() => mergeInstructions()}
 					disabled={instructionsToMerge.length < 2}
-          style={{fontSize: '0.9375rem',
-            fontWeight: instructionsToMerge.length >= 2 ? '800' : '400',
-            fontFamily: 'GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif',
-            color: instructionsToMerge.length >= 2 ? '#fff' : 'gray',
-            width: '150px',
-            background: instructionsToMerge.length >= 2 ? '#052962' : 'transparent', // Change background based on condition
-            padding: '8px',
-            cursor: instructionsToMerge.length >= 2 ? 'pointer' : 'default'
-          }}
+					style={{
+						fontSize: '0.9375rem',
+						fontWeight: instructionsToMerge.length >= 2 ? '800' : '400',
+						fontFamily:
+							'GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif',
+						color: instructionsToMerge.length >= 2 ? '#fff' : 'gray',
+						width: '150px',
+						background:
+							instructionsToMerge.length >= 2 ? '#052962' : 'transparent', // Change background based on condition
+						padding: '8px',
+						cursor: instructionsToMerge.length >= 2 ? 'pointer' : 'default',
+					}}
 				>
 					Merge instructions
 				</button>

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -6,12 +6,8 @@ import { ActionType } from '../../interfaces/main';
 import minBy from 'lodash-es/minBy';
 import { actions } from '../../actions/recipeActions';
 import { ImageObject } from '../../interfaces/main';
-import {
-	isValidGridUrl,
-	useGridSelector,
-} from 'components/curation/grid-selector';
+import { WithGridSelector } from 'components/curation/grid-selector';
 import { css } from '@emotion/react';
-import { is } from '@react-three/fiber/dist/declarations/src/core/utils';
 
 type assetsInfo = {
 	assets: imageInfo[];
@@ -103,119 +99,78 @@ const PictureGrid = ({
 	dispatcher,
 }: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
-	const [maybeGridSelector, gridSelectorCallback] = useGridSelector();
-	const [isDropTarget, setIsDropTarget] = useState(false);
 	return (
 		<>
 			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
 				Images featured in the canonical article
 			</h3>
-			<div
-				onDragEnter={(e) => {
-					if (e.dataTransfer.types.includes('text/uri-list')) {
-						e.preventDefault();
-						setIsDropTarget(true);
-					}
+			<WithGridSelector
+				callback={(chosenImage) => {
+					console.log(chosenImage); // TODO - do something with this such as save it etc.
 				}}
-				onDragLeave={() => setIsDropTarget(false)}
-				onDragEnd={() => setIsDropTarget(false)}
-				onDragExit={() => setIsDropTarget(false)}
-				onDragOver={(e) => {
-					if (e.dataTransfer.types.includes('text/uri-list')) {
-						e.preventDefault();
-					}
-				}}
-				onDrop={(e) => {
-					e.preventDefault();
-					gridSelectorCallback(e.dataTransfer.getData('URL')).then(console.log);
-					setIsDropTarget(false);
-				}}
-				css={css`
-					position: relative;
-					display: grid;
-					grid-template-columns: 20% 20% 20% 20% 20%;
-					grid-template-rows: auto;
-					height: auto;
-					grid-template-areas: '1' '2' '3' '4' '5';
-					margin-bottom: 30px;
-					border-color: black;
-					border-width: 2px;
-				`}
 			>
-				{isDropTarget && (
-					<div
-						css={css`
-							position: absolute;
-							top: 0;
-							left: 0;
-							width: 100%;
-							height: 100%;
-							background: rgba(0, 0, 0, 0.5);
-							border: 2px dashed black;
-						`}
-					/>
-				)}
-				{picObjects.map((p, i) => {
-					return (
-						<div
-							onMouseOver={() => setHover(i)}
-							onMouseOut={() => setHover(-1)}
-							onClick={() =>
-								select(
-									picObjects[i],
-									picObjects[i] === selectedImage,
-									setSelectedImage,
-									dispatcher,
-								)
-							}
-							css={{
-								gridArea: `${Math.floor(i / 5 + 1)}`,
-								justifyItems: 'center',
-								display: 'grid',
-								align: 'center',
-								maxWidth: '100%',
-								alignContent: 'center',
-								borderColor: 'black',
-								borderWidth: '1px',
-								cursor: 'pointer',
-								pointerEvents: 'visible',
-							}}
-							key={`img_${i}`}
-						>
-							<img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
+				<div
+					css={css`
+						position: relative;
+						display: grid;
+						grid-template-columns: 20% 20% 20% 20% 20%;
+						grid-template-rows: auto;
+						height: auto;
+						grid-template-areas: '1' '2' '3' '4' '5';
+						margin-bottom: 30px;
+						border-color: black;
+						border-width: 2px;
+					`}
+				>
+					{picObjects.map((p, i) => {
+						return (
 							<div
-								key={`tile-icon-bar-${i}`}
-								style={{
-									pointerEvents: 'none',
-									opacity: 1,
-									position: 'relative',
-									top: '-90px',
-									height: '36px',
-									width: '100%',
+								onMouseOver={() => setHover(i)}
+								onMouseOut={() => setHover(-1)}
+								onClick={() =>
+									select(
+										picObjects[i],
+										picObjects[i] === selectedImage,
+										setSelectedImage,
+										dispatcher,
+									)
+								}
+								css={{
+									gridArea: `${Math.floor(i / 5 + 1)}`,
+									justifyItems: 'center',
+									display: 'grid',
+									align: 'center',
+									maxWidth: '100%',
+									alignContent: 'center',
+									borderColor: 'black',
+									borderWidth: '1px',
+									cursor: 'pointer',
+									pointerEvents: 'visible',
 								}}
+								key={`img_${i}`}
 							>
-								<CheckButton
-									isSelected={picObjects[i]?.url === selectedImage?.url}
-									hover={i === picHovered}
-								/>
+								<img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
+								<div
+									key={`tile-icon-bar-${i}`}
+									style={{
+										pointerEvents: 'none',
+										opacity: 1,
+										position: 'relative',
+										top: '-90px',
+										height: '36px',
+										width: '100%',
+									}}
+								>
+									<CheckButton
+										isSelected={picObjects[i]?.url === selectedImage?.url}
+										hover={i === picHovered}
+									/>
+								</div>
 							</div>
-						</div>
-					);
-				})}
-			</div>
-			{maybeGridSelector}
-			<button
-				onClick={() => {
-					gridSelectorCallback().then((maybeImageObject) => {
-						console.log(maybeImageObject);
-					});
-				}}
-				css={css`
-					font-size: 40px;
-				`}
-			>
-				➕
-			</button>
+						);
+					})}
+				</div>
+			</WithGridSelector>
 			<hr />
 		</>
 	);

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -10,111 +10,111 @@ import { WithGridSelector } from 'components/curation/grid-selector';
 import { css } from '@emotion/react';
 
 type assetsInfo = {
-  assets: imageInfo[];
+	assets: imageInfo[];
 };
 
 type imageInfo = {
-  typeData: typeDataTypes;
-  file: string;
+	typeData: typeDataTypes;
+	file: string;
 };
 
 type typeDataTypes = {
-  altText: string;
-  caption: string;
-  credit: string;
-  displayCredit: string;
-  height: string;
-  imageType: string;
-  mediaApiUri: string;
-  mediaId: string;
-  secureFile: string;
-  source: string;
-  width: string;
+	altText: string;
+	caption: string;
+	credit: string;
+	displayCredit: string;
+	height: string;
+	imageType: string;
+	mediaApiUri: string;
+	mediaId: string;
+	secureFile: string;
+	source: string;
+	width: string;
 };
 
 const findSmallestVersion = (assets: imageInfo[]): imageInfo => {
-  /* Return asset with smallest 'width' */
-  return minBy(assets, ({ typeData }) => typeData.width);
+	/* Return asset with smallest 'width' */
+	return minBy(assets, ({ typeData }) => typeData.width);
 };
 
 const inferCropId = (url: string): string => {
-  const parts = url.split('/');
-  const cropId = parts[parts.length - 2];
-  if (cropId !== undefined) {
-    return cropId;
-  } else {
-    console.error('Could not infer cropId from url: ', url);
-    return '';
-  }
+	const parts = url.split('/');
+	const cropId = parts[parts.length - 2];
+	if (cropId !== undefined) {
+		return cropId;
+	} else {
+		console.error('Could not infer cropId from url: ', url);
+		return '';
+	}
 };
 
 const getPictureObjects = (elems: assetsInfo[] | undefined): ImageObject[] => {
-  if (elems === undefined) {
-    return [];
-  } else {
-    return elems.reduce((acc, el) => {
-      const smallestAsset = findSmallestVersion(el.assets);
-      if (smallestAsset.file) {
-        acc.push({
-          url: smallestAsset.file,
-          mediaId: smallestAsset.typeData.mediaId,
-          cropId: inferCropId(smallestAsset.file),
-          source: smallestAsset.typeData.source,
-          photographer: smallestAsset.typeData.displayCredit,
-          imageType: smallestAsset.typeData.imageType,
-          caption: smallestAsset.typeData.caption,
-          mediaApiUri: smallestAsset.typeData.mediaApiUri,
-        });
-      }
-      return acc;
-    }, [] as ImageObject[]);
-  }
+	if (elems === undefined) {
+		return [];
+	} else {
+		return elems.reduce((acc, el) => {
+			const smallestAsset = findSmallestVersion(el.assets);
+			if (smallestAsset.file) {
+				acc.push({
+					url: smallestAsset.file,
+					mediaId: smallestAsset.typeData.mediaId,
+					cropId: inferCropId(smallestAsset.file),
+					source: smallestAsset.typeData.source,
+					photographer: smallestAsset.typeData.displayCredit,
+					imageType: smallestAsset.typeData.imageType,
+					caption: smallestAsset.typeData.caption,
+					mediaApiUri: smallestAsset.typeData.mediaApiUri,
+				});
+			}
+			return acc;
+		}, [] as ImageObject[]);
+	}
 };
 
 const select = (
-  imageObject: ImageObject,
-  isSelected: boolean,
-  setSelectedImage: Dispatch<ImageObject | null>,
-  dispatcher: Dispatch<ActionType>,
+	imageObject: ImageObject,
+	isSelected: boolean,
+	setSelectedImage: Dispatch<ImageObject | null>,
+	dispatcher: Dispatch<ActionType>,
 ): void => {
-  const obj = isSelected ? null : imageObject;
-  setSelectedImage(obj);
-  dispatcher({
-    type: actions.selectImg,
-    payload: obj,
-  });
+	const obj = isSelected ? null : imageObject;
+	setSelectedImage(obj);
+	dispatcher({
+		type: actions.selectImg,
+		payload: obj,
+	});
 };
 
 interface PictureGridProps {
-  canonicalArticlePicObjects: ImageObject[];
-  selectedImage: ImageObject | null;
-  setSelectedImage: Dispatch<ImageObject | null>;
-  dispatcher: Dispatch<ActionType>;
+	canonicalArticlePicObjects: ImageObject[];
+	selectedImage: ImageObject | null;
+	setSelectedImage: Dispatch<ImageObject | null>;
+	dispatcher: Dispatch<ActionType>;
 }
 
 const PictureGrid = ({
-  canonicalArticlePicObjects,
-  selectedImage,
-  setSelectedImage,
-  dispatcher,
+	canonicalArticlePicObjects,
+	selectedImage,
+	setSelectedImage,
+	dispatcher,
 }: PictureGridProps) => {
-  const [picHovered, setHover] = useState(-1);
-  const selectedImageIsFromGrid = !canonicalArticlePicObjects.some(
-    (p) => p.url === selectedImage?.url,
-  );
-  return (
-    <>
-      <h3 css={{ fontFamily: 'GuardianTextSans' }}>
-        Images featured in the canonical article
-      </h3>
-      <WithGridSelector
-        callback={(chosenImage) => {
-          const isSelected = chosenImage?.url === selectedImage?.url;
-          select(chosenImage, isSelected, setSelectedImage, dispatcher);
-        }}
-      >
-        <div
-          css={css`
+	const [picHovered, setHover] = useState(-1);
+	const selectedImageIsFromGrid = !canonicalArticlePicObjects.some(
+		(p) => p.url === selectedImage?.url,
+	);
+	return (
+		<>
+			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
+				Images featured in the canonical article
+			</h3>
+			<WithGridSelector
+				callback={(chosenImage) => {
+					const isSelected = chosenImage?.url === selectedImage?.url;
+					select(chosenImage, isSelected, setSelectedImage, dispatcher);
+				}}
+			>
+				<div
+					css={css`
 						position: relative;
 						display: grid;
 						grid-template-columns: 20% 20% 20% 20% 20%;
@@ -125,107 +125,110 @@ const PictureGrid = ({
 						border-color: black;
 						border-width: 2px;
 					`}
-        >
-          {canonicalArticlePicObjects.map((p, i) => {
-            return (
-              <div
-                onMouseOver={() => setHover(i)}
-                onMouseOut={() => setHover(-1)}
-                onClick={() =>
-                  select(
-                    canonicalArticlePicObjects[i],
-                    canonicalArticlePicObjects[i] === selectedImage,
-                    setSelectedImage,
-                    dispatcher,
-                  )
-                }
-                css={{
-                  gridArea: `${Math.floor(i / 5 + 1)}`,
-                  justifyItems: 'center',
-                  display: 'grid',
-                  align: 'center',
-                  maxWidth: '100%',
-                  alignContent: 'center',
-                  borderColor: 'black',
-                  borderWidth: '1px',
-                  cursor: 'pointer',
-                  pointerEvents: 'visible',
-                }}
-                key={`img_${i}`}
-              >
-                <img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
-                <div
-                  key={`tile-icon-bar-${i}`}
-                  style={{
-                    pointerEvents: 'none',
-                    opacity: 1,
-                    position: 'relative',
-                    top: '-90px',
-                    height: '36px',
-                    width: '100%',
-                  }}
-                >
-                  <CheckButton
-                    isSelected={
-                      canonicalArticlePicObjects[i]?.url === selectedImage?.url
-                    }
-                    hover={i === picHovered}
-                  />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-        <h3>Custom image/crop selected from the Grid</h3>
-        {(selectedImageIsFromGrid && ) ? (
-          <div>
-            <img
-              style={{ maxWidth: '30%' }}
-              src={selectedImage?.url}
-              alt={selectedImage?.url}
-            />
-            <CheckButton isSelected={true} hover={false} />
-          </div>
-        ) : (
-          <div>
-            <p>Select an image from the Grid using the plus button below, or drag one over this space from Pinboard.s</p>
-          </div>
-        )}
-      </WithGridSelector>
-      <hr />
-    </>
-  );
+				>
+					{canonicalArticlePicObjects.map((p, i) => {
+						return (
+							<div
+								onMouseOver={() => setHover(i)}
+								onMouseOut={() => setHover(-1)}
+								onClick={() =>
+									select(
+										canonicalArticlePicObjects[i],
+										canonicalArticlePicObjects[i] === selectedImage,
+										setSelectedImage,
+										dispatcher,
+									)
+								}
+								css={{
+									gridArea: `${Math.floor(i / 5 + 1)}`,
+									justifyItems: 'center',
+									display: 'grid',
+									align: 'center',
+									maxWidth: '100%',
+									alignContent: 'center',
+									borderColor: 'black',
+									borderWidth: '1px',
+									cursor: 'pointer',
+									pointerEvents: 'visible',
+								}}
+								key={`img_${i}`}
+							>
+								<img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
+								<div
+									key={`tile-icon-bar-${i}`}
+									style={{
+										pointerEvents: 'none',
+										opacity: 1,
+										position: 'relative',
+										top: '-90px',
+										height: '36px',
+										width: '100%',
+									}}
+								>
+									<CheckButton
+										isSelected={
+											canonicalArticlePicObjects[i]?.url === selectedImage?.url
+										}
+										hover={i === picHovered}
+									/>
+								</div>
+							</div>
+						);
+					})}
+				</div>
+				<h3>Custom image/crop selected from the Grid</h3>
+				{selectedImageIsFromGrid ? (
+					<div>
+						<img
+							style={{ maxWidth: '30%' }}
+							src={selectedImage?.url}
+							alt={selectedImage?.url}
+						/>
+						<CheckButton isSelected={true} hover={false} />
+					</div>
+				) : (
+					<div>
+						<p>
+							Select an image from the Grid using the plus button below, or drag
+							one over this space from Pinboard.
+						</p>
+					</div>
+				)}
+			</WithGridSelector>
+			<hr />
+		</>
+	);
 };
 
 interface ImagePickerProps {
-  isLoading: boolean;
-  html: Record<string, unknown> | null;
-  selectedImage: ImageObject | null;
-  setSelectedImage: (img: ImageObject | null) => void;
-  dispatcher: Dispatch<ActionType>;
+	isLoading: boolean;
+	html: Record<string, unknown> | null;
+	selectedImage: ImageObject | null;
+	setSelectedImage: (img: ImageObject | null) => void;
+	dispatcher: Dispatch<ActionType>;
 }
 
 const ImagePicker = ({
-  isLoading,
-  html,
-  selectedImage,
-  setSelectedImage,
-  dispatcher,
+	isLoading,
+	html,
+	selectedImage,
+	setSelectedImage,
+	dispatcher,
 }: ImagePickerProps): JSX.Element => {
-  if (isLoading || html === null) {
-    return <h3> Loading pictures... </h3>;
-  } else {
-    const picObjects = getPictureObjects(html.elements as assetsInfo[]);
+	if (isLoading || html === null) {
+		return <h3> Loading pictures... </h3>;
+	} else {
+		const picObjects = getPictureObjects(html.elements as assetsInfo[]);
 
-    return (
-      <PictureGrid
-        canonicalArticlePicObjects={picObjects}
-        selectedImage={selectedImage}
-        setSelectedImage={setSelectedImage}
-        dispatcher={dispatcher}
-      />
-    );
-  }
+		return (
+			<PictureGrid
+				canonicalArticlePicObjects={picObjects}
+				selectedImage={selectedImage}
+				setSelectedImage={setSelectedImage}
+				dispatcher={dispatcher}
+			/>
+		);
+	}
 };
 
 export default ImagePicker;

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -99,9 +99,9 @@ const PictureGrid = ({
 	dispatcher,
 }: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
-	const selectedImageIsFromGrid = !canonicalArticlePicObjects.some(
-		(p) => p.url === selectedImage?.url,
-	);
+	const selectedImageIsFromGrid =
+		!canonicalArticlePicObjects.some((p) => p.url === selectedImage?.url) &&
+		selectedImage !== null;
 	return (
 		<>
 			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
@@ -190,7 +190,7 @@ const PictureGrid = ({
 					<div>
 						<p>
 							Select an image from the Grid using the plus button below, or drag
-							one over this space from Pinboard.
+							one in from Pinboard 📌
 						</p>
 					</div>
 				)}

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -100,8 +100,8 @@ const PictureGrid = ({
 }: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
 	const selectedImageIsFromGrid =
-		!canonicalArticlePicObjects.some((p) => p.url === selectedImage?.url) &&
-		selectedImage !== null;
+		selectedImage &&
+		!canonicalArticlePicObjects.some((p) => p.url === selectedImage.url);
 	return (
 		<>
 			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
@@ -109,7 +109,7 @@ const PictureGrid = ({
 			</h3>
 			<WithGridSelector
 				callback={(chosenImage) => {
-					const isSelected = chosenImage?.url === selectedImage?.url;
+					const isSelected = false; // forces it to become selected, regardless of what's already selected
 					select(chosenImage, isSelected, setSelectedImage, dispatcher);
 				}}
 			>
@@ -178,11 +178,19 @@ const PictureGrid = ({
 				</div>
 				<h3>Custom image/crop selected from the Grid</h3>
 				{selectedImageIsFromGrid ? (
-					<div>
+					<div
+						css={css`
+							position: relative;
+							display: inline-block;
+						`}
+					>
 						<img
-							style={{ maxWidth: '30%' }}
-							src={selectedImage?.url}
-							alt={selectedImage?.url}
+							css={css`
+								max-width: 150px;
+								max-height: 150px;
+							`}
+							src={selectedImage.url}
+							alt={selectedImage.mediaId}
 						/>
 						<CheckButton isSelected={true} hover={false} />
 					</div>

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -10,107 +10,111 @@ import { WithGridSelector } from 'components/curation/grid-selector';
 import { css } from '@emotion/react';
 
 type assetsInfo = {
-	assets: imageInfo[];
+  assets: imageInfo[];
 };
 
 type imageInfo = {
-	typeData: typeDataTypes;
-	file: string;
+  typeData: typeDataTypes;
+  file: string;
 };
 
 type typeDataTypes = {
-	altText: string;
-	caption: string;
-	credit: string;
-	displayCredit: string;
-	height: string;
-	imageType: string;
-	mediaApiUri: string;
-	mediaId: string;
-	secureFile: string;
-	source: string;
-	width: string;
+  altText: string;
+  caption: string;
+  credit: string;
+  displayCredit: string;
+  height: string;
+  imageType: string;
+  mediaApiUri: string;
+  mediaId: string;
+  secureFile: string;
+  source: string;
+  width: string;
 };
 
 const findSmallestVersion = (assets: imageInfo[]): imageInfo => {
-	/* Return asset with smallest 'width' */
-	return minBy(assets, ({ typeData }) => typeData.width);
+  /* Return asset with smallest 'width' */
+  return minBy(assets, ({ typeData }) => typeData.width);
 };
 
 const inferCropId = (url: string): string => {
-	const parts = url.split('/');
-	const cropId = parts[parts.length - 2];
-	if (cropId !== undefined) {
-		return cropId;
-	} else {
-		console.error('Could not infer cropId from url: ', url);
-		return '';
-	}
+  const parts = url.split('/');
+  const cropId = parts[parts.length - 2];
+  if (cropId !== undefined) {
+    return cropId;
+  } else {
+    console.error('Could not infer cropId from url: ', url);
+    return '';
+  }
 };
 
 const getPictureObjects = (elems: assetsInfo[] | undefined): ImageObject[] => {
-	if (elems === undefined) {
-		return [];
-	} else {
-		return elems.reduce((acc, el) => {
-			const smallestAsset = findSmallestVersion(el.assets);
-			if (smallestAsset.file) {
-				acc.push({
-					url: smallestAsset.file,
-					mediaId: smallestAsset.typeData.mediaId,
-					cropId: inferCropId(smallestAsset.file),
-					source: smallestAsset.typeData.source,
-					photographer: smallestAsset.typeData.displayCredit,
-					imageType: smallestAsset.typeData.imageType,
-					caption: smallestAsset.typeData.caption,
-					mediaApiUri: smallestAsset.typeData.mediaApiUri,
-				});
-			}
-			return acc;
-		}, [] as ImageObject[]);
-	}
+  if (elems === undefined) {
+    return [];
+  } else {
+    return elems.reduce((acc, el) => {
+      const smallestAsset = findSmallestVersion(el.assets);
+      if (smallestAsset.file) {
+        acc.push({
+          url: smallestAsset.file,
+          mediaId: smallestAsset.typeData.mediaId,
+          cropId: inferCropId(smallestAsset.file),
+          source: smallestAsset.typeData.source,
+          photographer: smallestAsset.typeData.displayCredit,
+          imageType: smallestAsset.typeData.imageType,
+          caption: smallestAsset.typeData.caption,
+          mediaApiUri: smallestAsset.typeData.mediaApiUri,
+        });
+      }
+      return acc;
+    }, [] as ImageObject[]);
+  }
 };
 
 const select = (
-	imageObject: ImageObject,
-	isSelected: boolean,
-	setSelectedImage: Dispatch<ImageObject | null>,
-	dispatcher: Dispatch<ActionType>,
+  imageObject: ImageObject,
+  isSelected: boolean,
+  setSelectedImage: Dispatch<ImageObject | null>,
+  dispatcher: Dispatch<ActionType>,
 ): void => {
-	const obj = isSelected ? null : imageObject;
-	setSelectedImage(obj);
-	dispatcher({
-		type: actions.selectImg,
-		payload: obj,
-	});
+  const obj = isSelected ? null : imageObject;
+  setSelectedImage(obj);
+  dispatcher({
+    type: actions.selectImg,
+    payload: obj,
+  });
 };
 
 interface PictureGridProps {
-	picObjects: ImageObject[];
-	selectedImage: ImageObject | null;
-	setSelectedImage: Dispatch<ImageObject | null>;
-	dispatcher: Dispatch<ActionType>;
+  canonicalArticlePicObjects: ImageObject[];
+  selectedImage: ImageObject | null;
+  setSelectedImage: Dispatch<ImageObject | null>;
+  dispatcher: Dispatch<ActionType>;
 }
 
 const PictureGrid = ({
-	picObjects,
-	selectedImage,
-	setSelectedImage,
-	dispatcher,
+  canonicalArticlePicObjects,
+  selectedImage,
+  setSelectedImage,
+  dispatcher,
 }: PictureGridProps) => {
-	const [picHovered, setHover] = useState(-1);
-	return (
-		<>
-			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
-				Images featured in the canonical article
-			</h3>
-			<WithGridSelector
-				callback={(chosenImage) => {
-					console.log(chosenImage); // TODO - do something with this such as save it etc.
-				}}
-			>
-				<div
-					css={css`
+  const [picHovered, setHover] = useState(-1);
+  const selectedImageIsFromGrid = !canonicalArticlePicObjects.some(
+    (p) => p.url === selectedImage?.url,
+  );
+  return (
+    <>
+      <h3 css={{ fontFamily: 'GuardianTextSans' }}>
+        Images featured in the canonical article
+      </h3>
+      <WithGridSelector
+        callback={(chosenImage) => {
+          const isSelected = chosenImage?.url === selectedImage?.url;
+          select(chosenImage, isSelected, setSelectedImage, dispatcher);
+        }}
+      >
+        <div
+          css={css`
 						position: relative;
 						display: grid;
 						grid-template-columns: 20% 20% 20% 20% 20%;
@@ -121,90 +125,107 @@ const PictureGrid = ({
 						border-color: black;
 						border-width: 2px;
 					`}
-				>
-					{picObjects.map((p, i) => {
-						return (
-							<div
-								onMouseOver={() => setHover(i)}
-								onMouseOut={() => setHover(-1)}
-								onClick={() =>
-									select(
-										picObjects[i],
-										picObjects[i] === selectedImage,
-										setSelectedImage,
-										dispatcher,
-									)
-								}
-								css={{
-									gridArea: `${Math.floor(i / 5 + 1)}`,
-									justifyItems: 'center',
-									display: 'grid',
-									align: 'center',
-									maxWidth: '100%',
-									alignContent: 'center',
-									borderColor: 'black',
-									borderWidth: '1px',
-									cursor: 'pointer',
-									pointerEvents: 'visible',
-								}}
-								key={`img_${i}`}
-							>
-								<img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
-								<div
-									key={`tile-icon-bar-${i}`}
-									style={{
-										pointerEvents: 'none',
-										opacity: 1,
-										position: 'relative',
-										top: '-90px',
-										height: '36px',
-										width: '100%',
-									}}
-								>
-									<CheckButton
-										isSelected={picObjects[i]?.url === selectedImage?.url}
-										hover={i === picHovered}
-									/>
-								</div>
-							</div>
-						);
-					})}
-				</div>
-			</WithGridSelector>
-			<hr />
-		</>
-	);
+        >
+          {canonicalArticlePicObjects.map((p, i) => {
+            return (
+              <div
+                onMouseOver={() => setHover(i)}
+                onMouseOut={() => setHover(-1)}
+                onClick={() =>
+                  select(
+                    canonicalArticlePicObjects[i],
+                    canonicalArticlePicObjects[i] === selectedImage,
+                    setSelectedImage,
+                    dispatcher,
+                  )
+                }
+                css={{
+                  gridArea: `${Math.floor(i / 5 + 1)}`,
+                  justifyItems: 'center',
+                  display: 'grid',
+                  align: 'center',
+                  maxWidth: '100%',
+                  alignContent: 'center',
+                  borderColor: 'black',
+                  borderWidth: '1px',
+                  cursor: 'pointer',
+                  pointerEvents: 'visible',
+                }}
+                key={`img_${i}`}
+              >
+                <img style={{ maxWidth: 'inherit' }} src={p.url} alt={p.url} />
+                <div
+                  key={`tile-icon-bar-${i}`}
+                  style={{
+                    pointerEvents: 'none',
+                    opacity: 1,
+                    position: 'relative',
+                    top: '-90px',
+                    height: '36px',
+                    width: '100%',
+                  }}
+                >
+                  <CheckButton
+                    isSelected={
+                      canonicalArticlePicObjects[i]?.url === selectedImage?.url
+                    }
+                    hover={i === picHovered}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <h3>Custom image/crop selected from the Grid</h3>
+        {(selectedImageIsFromGrid && ) ? (
+          <div>
+            <img
+              style={{ maxWidth: '30%' }}
+              src={selectedImage?.url}
+              alt={selectedImage?.url}
+            />
+            <CheckButton isSelected={true} hover={false} />
+          </div>
+        ) : (
+          <div>
+            <p>Select an image from the Grid using the plus button below, or drag one over this space from Pinboard.s</p>
+          </div>
+        )}
+      </WithGridSelector>
+      <hr />
+    </>
+  );
 };
 
 interface ImagePickerProps {
-	isLoading: boolean;
-	html: Record<string, unknown> | null;
-	selectedImage: ImageObject | null;
-	setSelectedImage: (img: ImageObject | null) => void;
-	dispatcher: Dispatch<ActionType>;
+  isLoading: boolean;
+  html: Record<string, unknown> | null;
+  selectedImage: ImageObject | null;
+  setSelectedImage: (img: ImageObject | null) => void;
+  dispatcher: Dispatch<ActionType>;
 }
 
 const ImagePicker = ({
-	isLoading,
-	html,
-	selectedImage,
-	setSelectedImage,
-	dispatcher,
+  isLoading,
+  html,
+  selectedImage,
+  setSelectedImage,
+  dispatcher,
 }: ImagePickerProps): JSX.Element => {
-	if (isLoading || html === null) {
-		return <h3> Loading pictures... </h3>;
-	} else {
-		const picObjects = getPictureObjects(html.elements as assetsInfo[]);
+  if (isLoading || html === null) {
+    return <h3> Loading pictures... </h3>;
+  } else {
+    const picObjects = getPictureObjects(html.elements as assetsInfo[]);
 
-		return (
-			<PictureGrid
-				picObjects={picObjects}
-				selectedImage={selectedImage}
-				setSelectedImage={setSelectedImage}
-				dispatcher={dispatcher}
-			/>
-		);
-	}
+    return (
+      <PictureGrid
+        canonicalArticlePicObjects={picObjects}
+        selectedImage={selectedImage}
+        setSelectedImage={setSelectedImage}
+        dispatcher={dispatcher}
+      />
+    );
+  }
 };
 
 export default ImagePicker;

--- a/recipes-client/components/form/form-image-picker.tsx
+++ b/recipes-client/components/form/form-image-picker.tsx
@@ -6,6 +6,12 @@ import { ActionType } from '../../interfaces/main';
 import minBy from 'lodash-es/minBy';
 import { actions } from '../../actions/recipeActions';
 import { ImageObject } from '../../interfaces/main';
+import {
+	isValidGridUrl,
+	useGridSelector,
+} from 'components/curation/grid-selector';
+import { css } from '@emotion/react';
+import { is } from '@react-three/fiber/dist/declarations/src/core/utils';
 
 type assetsInfo = {
 	assets: imageInfo[];
@@ -97,24 +103,58 @@ const PictureGrid = ({
 	dispatcher,
 }: PictureGridProps) => {
 	const [picHovered, setHover] = useState(-1);
+	const [maybeGridSelector, gridSelectorCallback] = useGridSelector();
+	const [isDropTarget, setIsDropTarget] = useState(false);
 	return (
 		<>
 			<h3 css={{ fontFamily: 'GuardianTextSans' }}>
-				Available pictures for the featured image
+				Images featured in the canonical article
 			</h3>
 			<div
-				css={{
-					display: 'grid',
-					gridTemplateColumns: '20% 20% 20% 20% 20%',
-					gridTemplateRows: 'auto',
-					height: 'auto',
-					// gridTemplateRows: "40px 1fr 30px",
-					gridTemplateAreas: `"1" "2" "3" "4" "5"`,
-					marginBottom: '30px',
-					borderColor: 'black',
-					borderWidth: '2px',
+				onDragEnter={(e) => {
+					if (e.dataTransfer.types.includes('text/uri-list')) {
+						e.preventDefault();
+						setIsDropTarget(true);
+					}
 				}}
+				onDragLeave={() => setIsDropTarget(false)}
+				onDragEnd={() => setIsDropTarget(false)}
+				onDragExit={() => setIsDropTarget(false)}
+				onDragOver={(e) => {
+					if (e.dataTransfer.types.includes('text/uri-list')) {
+						e.preventDefault();
+					}
+				}}
+				onDrop={(e) => {
+					e.preventDefault();
+					gridSelectorCallback(e.dataTransfer.getData('URL')).then(console.log);
+					setIsDropTarget(false);
+				}}
+				css={css`
+					position: relative;
+					display: grid;
+					grid-template-columns: 20% 20% 20% 20% 20%;
+					grid-template-rows: auto;
+					height: auto;
+					grid-template-areas: '1' '2' '3' '4' '5';
+					margin-bottom: 30px;
+					border-color: black;
+					border-width: 2px;
+				`}
 			>
+				{isDropTarget && (
+					<div
+						css={css`
+							position: absolute;
+							top: 0;
+							left: 0;
+							width: 100%;
+							height: 100%;
+							background: rgba(0, 0, 0, 0.5);
+							border: 2px dashed black;
+						`}
+					/>
+				)}
 				{picObjects.map((p, i) => {
 					return (
 						<div
@@ -163,6 +203,19 @@ const PictureGrid = ({
 					);
 				})}
 			</div>
+			{maybeGridSelector}
+			<button
+				onClick={() => {
+					gridSelectorCallback().then((maybeImageObject) => {
+						console.log(maybeImageObject);
+					});
+				}}
+				css={css`
+					font-size: 40px;
+				`}
+			>
+				➕
+			</button>
 			<hr />
 		</>
 	);

--- a/recipes-client/components/layout/header.tsx
+++ b/recipes-client/components/layout/header.tsx
@@ -2,31 +2,33 @@
 import { css } from '@emotion/react';
 import { headline, palette } from '@guardian/source-foundations';
 
-const Header = (): JSX.Element => (
-	<header
-		css={css`
-			${headline.small()};
-			text-align: center;
-			padding: 2rem 0;
-			background-color: ${palette.brand[400]};
-			a {
-				text-decoration: none;
-				color: ${palette.neutral[100]};
+const Header = (): JSX.Element => {
+	return (
+		<header
+			css={css`
+				${headline.small()};
+				text-align: center;
 				padding: 2rem 0;
-				:hover {
-					opacity: 0.8;
+				background-color: ${palette.brand[400]};
+				a {
+					text-decoration: none;
+					color: ${palette.neutral[100]};
+					padding: 2rem 0;
+					:hover {
+						opacity: 0.8;
+					}
 				}
-			}
-			h2 {
-				margin: 0;
-			}
-		`}
-	>
-		<a href="/">
-			<h2>Hatch</h2>
-			<span>A (temporary) recipe data curation tool</span>
-		</a>
-	</header>
-);
+				h2 {
+					margin: 0;
+				}
+			`}
+		>
+			<a href="/">
+				<h2>Hatch</h2>
+				<span>A (temporary) recipe data curation tool</span>
+			</a>
+		</header>
+	);
+};
 
 export default Header;

--- a/recipes-client/components/preview/data-preview.tsx
+++ b/recipes-client/components/preview/data-preview.tsx
@@ -68,7 +68,10 @@ export const DataPreview = ({ recipeData }: DataPreviewProps) => {
 					{recipeData.featuredImage ? (
 						<img
 							src={recipeData.featuredImage.url}
-							alt={`Featured image of ${recipeData.title} recipe`}
+							alt={
+								recipeData.featuredImage.caption ||
+								`Featured image of ${recipeData.title} recipe`
+							}
 							css={imageStyles}
 						/>
 					) : (

--- a/recipes-client/components/reusables/check-button.tsx
+++ b/recipes-client/components/reusables/check-button.tsx
@@ -14,8 +14,10 @@ const CheckButton = ({
 			title="Select this one"
 			style={{
 				visibility: vis,
-				background: 'none',
-				float: 'left',
+				position: 'absolute',
+				top: '50%',
+				left: '50%',
+				transform: 'translate(-50%, -50%)',
 				width: '36px',
 				height: '36px',
 				border: 'none',

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -5,7 +5,7 @@ import RecipeComponent from '../components/curation/recipe-component';
 import GuFrame from '../components/curation/gu-frame';
 import ImagePicker from '../components/form/form-image-picker';
 import CurationOptionsBar, {
-	postRecipe,
+  postRecipe,
 } from '../components/curation/curation-options-bar';
 
 import { useParams } from 'react-router-dom';
@@ -24,197 +24,197 @@ import { useIdleTimer } from 'react-idle-timer';
 import { useNavigate } from 'react-router-dom';
 
 const Curation = () => {
-	const { section: id } = useParams();
-	const articleId = id ? `/${id}` : '';
-	const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
-	const [capiId, setCapiId] = useState<string | null>(null);
-	const [selectedImage, setSelectedImage] = useState<ImageObject | null>(null);
-	const scrubbedId = articleId.replace(/^\/+/, '');
+  const { section: id } = useParams();
+  const articleId = id ? `/${id}` : '';
+  const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
+  const [capiId, setCapiId] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<ImageObject | null>(null);
+  const scrubbedId = articleId.replace(/^\/+/, '');
 
-	const [selectedTab, setSelectedTab] = useState('summary');
+  const [selectedTab, setSelectedTab] = useState('summary');
 
-	// idle timer
-	const [remaining, setRemaining] = useState<number>(0);
-	const [openAlert, setOpenAlert] = useState<boolean>(false);
-	const timeout = 180000; // 3 minutes
-	const promptBeforeIdle = 120000; // 2 minutes
-	const navigate = useNavigate();
+  // idle timer
+  const [remaining, setRemaining] = useState<number>(0);
+  const [openAlert, setOpenAlert] = useState<boolean>(false);
+  const timeout = 180000; // 3 minutes
+  const promptBeforeIdle = 120000; // 2 minutes
+  const navigate = useNavigate();
 
-	const onIdle = () => {
-		setOpenAlert(false);
-		navigate('/');
-	};
+  const onIdle = () => {
+    setOpenAlert(false);
+    navigate('/');
+  };
 
-	const onActive = () => {
-		setOpenAlert(false);
-	};
-	const onPrompt = () => {
-		setOpenAlert(true);
-	};
+  const onActive = () => {
+    setOpenAlert(false);
+  };
+  const onPrompt = () => {
+    setOpenAlert(true);
+  };
 
-	const { getRemainingTime, activate } = useIdleTimer({
-		onIdle,
-		onActive,
-		onPrompt,
-		timeout,
-		promptBeforeIdle,
-		throttle: 500,
-	});
+  const { getRemainingTime, activate } = useIdleTimer({
+    onIdle,
+    onActive,
+    onPrompt,
+    timeout,
+    promptBeforeIdle,
+    throttle: 500,
+  });
 
-	const handleStillHere = () => {
-		activate();
-	};
+  const handleStillHere = () => {
+    activate();
+  };
 
-	useEffect(() => {
-		const interval = setInterval(() => {
-			setRemaining(Math.ceil(getRemainingTime() / 1000));
-		}, 500);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining(Math.ceil(getRemainingTime() / 1000));
+    }, 500);
 
-		return () => {
-			clearInterval(interval);
-		};
-	});
+    return () => {
+      clearInterval(interval);
+    };
+  });
 
-	useEffect(() => {
-		const interval = setInterval(() => {
-			postRecipe(articleId, state.body)
-				.catch((err) => console.error(err))
-				.then(() =>
-					fetchAndDispatch(
-						`${location.origin}/api/db/${scrubbedId}`,
-						actions.init,
-						'body',
-						dispatch,
-					),
-				);
-		}, 60000);
-		return () => clearInterval(interval);
-	}, [state]);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      postRecipe(articleId, state.body)
+        .catch((err) => console.error(err))
+        .then(() =>
+          fetchAndDispatch(
+            `${location.origin}/api/db/${scrubbedId}`,
+            actions.init,
+            'body',
+            dispatch,
+          ),
+        );
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [state]);
 
-	useEffect(() => {
-		Promise.all([
-			// Get schema
-			fetchAndDispatch(
-				`${location.origin}${apiURL}${schemaEndpoint}`,
-				actions.init,
-				'schema',
-				dispatch,
-			),
-			// Get parsed recipe items
-			fetchAndDispatch(
-				`${location.origin}/api/db/${scrubbedId}`,
-				actions.init,
-				'body',
-				dispatch,
-			),
-		])
-			.then(() => {
-				// Get article content
-				if (state.body === null) {
-					return;
-				}
-				setSelectedImage(state.body.featuredImage);
-				setCapiId(state.body.canonicalArticle);
-				fetchAndDispatch(
-					`${location.origin}${capiProxy}/${state.body.canonicalArticle}`,
-					actions.init,
-					'html',
-					dispatch,
-				);
-				setLoadingFinished(dispatch);
-			})
-			.catch((err) => {
-				console.error(err);
-			});
-	}, [articleId, dispatch, state?.body?.canonicalArticle]);
+  useEffect(() => {
+    Promise.all([
+      // Get schema
+      fetchAndDispatch(
+        `${location.origin}${apiURL}${schemaEndpoint}`,
+        actions.init,
+        'schema',
+        dispatch,
+      ),
+      // Get parsed recipe items
+      fetchAndDispatch(
+        `${location.origin}/api/db/${scrubbedId}`,
+        actions.init,
+        'body',
+        dispatch,
+      ),
+    ])
+      .then(() => {
+        // Get article content
+        if (state.body === null) {
+          return;
+        }
+        setSelectedImage(state.body.featuredImage);
+        setCapiId(state.body.canonicalArticle);
+        fetchAndDispatch(
+          `${location.origin}${capiProxy}/${state.body.canonicalArticle}`,
+          actions.init,
+          'html',
+          dispatch,
+        );
+        setLoadingFinished(dispatch);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }, [articleId, dispatch, state?.body?.canonicalArticle]);
 
-	const tabsContent = [
-		{
-			id: 'summary',
-			text: 'Summary',
-			content: <DataPreview recipeData={state.body} />,
-		},
-		{
-			id: 'edit',
-			text: 'Edit',
-			content: (
-				<>
-					<ImagePicker
-						html={state.html}
-						selectedImage={selectedImage}
-						setSelectedImage={setSelectedImage}
-						isLoading={state.isLoading}
-						dispatcher={dispatch}
-					/>
-					<form>
-						{state.body && (
-							<RecipeComponent
-								isLoading={state.isLoading}
-								body={state.body}
-								schema={state.schema}
-								dispatcher={dispatch}
-							/>
-						)}
-					</form>
-				</>
-			),
-		},
-	];
+  const tabsContent = [
+    {
+      id: 'summary',
+      text: 'Summary',
+      content: <DataPreview recipeData={state.body} />,
+    },
+    {
+      id: 'edit',
+      text: 'Edit',
+      content: (
+        <>
+          <ImagePicker
+            html={state.html}
+            selectedImage={selectedImage}
+            setSelectedImage={setSelectedImage}
+            isLoading={state.isLoading}
+            dispatcher={dispatch}
+          />
+          <form>
+            {state.body && (
+              <RecipeComponent
+                isLoading={state.isLoading}
+                body={state.body}
+                schema={state.schema}
+                dispatcher={dispatch}
+              />
+            )}
+          </form>
+        </>
+      ),
+    },
+  ];
 
-	return (
-		<div css={gridLayout}>
-			<div css={footer}>
-				<div
-					className="modal"
-					style={{
-						display: openAlert ? 'flex' : 'none',
-						zIndex: '100',
-						width: '20em',
-						border: '2px solid gray',
-						background: 'white',
-						fontFamily: 'GuardianTextSans',
-						borderRadius: '1em',
-						padding: '1em',
-						position: 'absolute',
-						flexDirection: 'column',
-						alignItems: 'center',
-						left: 'calc(50vw - 10em)',
-						right: 'calc(50vh - 10em)',
-					}}
-				>
-					<h3>Are you still here?</h3>
-					<p>Redirecting in {remaining} seconds</p>
-					<button
-						css={{ fontFamily: 'GuardianTextSans' }}
-						onClick={handleStillHere}
-					>
-						I'm still here!
-					</button>
-				</div>
-				<CurationOptionsBar
-					articleId={articleId}
-					body={state.body}
-					dispatcher={dispatch}
-				/>
-			</div>
-			<div css={articleView}>{capiId && <GuFrame articlePath={capiId} />}</div>
-			<div css={dataView}>
-				<Tabs
-					tabsLabel="Toggle between form and preview"
-					tabElement="button"
-					tabs={tabsContent}
-					selectedTab={selectedTab}
-					onTabChange={(tabId: string): void => {
-						setSelectedTab(tabId);
-					}}
-				></Tabs>
-			</div>
-			<PinboardTrackAndPreselect
-				maybeComposerId={state?.body?.composerId}
-				maybeTitle={state?.body?.title}
-			/>
-		</div>
-	);
+  return (
+    <div css={gridLayout}>
+      <div css={footer}>
+        <div
+          className="modal"
+          style={{
+            display: openAlert ? 'flex' : 'none',
+            zIndex: '100',
+            width: '20em',
+            border: '2px solid gray',
+            background: 'white',
+            fontFamily: 'GuardianTextSans',
+            borderRadius: '1em',
+            padding: '1em',
+            position: 'absolute',
+            flexDirection: 'column',
+            alignItems: 'center',
+            left: 'calc(50vw - 10em)',
+            right: 'calc(50vh - 10em)',
+          }}
+        >
+          <h3>Are you still here?</h3>
+          <p>Redirecting in {remaining} seconds</p>
+          <button
+            css={{ fontFamily: 'GuardianTextSans' }}
+            onClick={handleStillHere}
+          >
+            I'm still here!
+          </button>
+        </div>
+        <CurationOptionsBar
+          articleId={articleId}
+          body={state.body}
+          dispatcher={dispatch}
+        />
+      </div>
+      <div css={articleView}>{capiId && <GuFrame articlePath={capiId} />}</div>
+      <div css={dataView}>
+        <Tabs
+          tabsLabel="Toggle between form and preview"
+          tabElement="button"
+          tabs={tabsContent}
+          selectedTab={selectedTab}
+          onTabChange={(tabId: string): void => {
+            setSelectedTab(tabId);
+          }}
+        ></Tabs>
+      </div>
+      <PinboardTrackAndPreselect
+        maybeComposerId={state?.body?.composerId}
+        maybeTitle={state?.body?.title}
+      />
+    </div>
+  );
 };
 
 export default Curation;

--- a/recipes-client/pages/curation.tsx
+++ b/recipes-client/pages/curation.tsx
@@ -5,7 +5,7 @@ import RecipeComponent from '../components/curation/recipe-component';
 import GuFrame from '../components/curation/gu-frame';
 import ImagePicker from '../components/form/form-image-picker';
 import CurationOptionsBar, {
-  postRecipe,
+	postRecipe,
 } from '../components/curation/curation-options-bar';
 
 import { useParams } from 'react-router-dom';
@@ -24,197 +24,197 @@ import { useIdleTimer } from 'react-idle-timer';
 import { useNavigate } from 'react-router-dom';
 
 const Curation = () => {
-  const { section: id } = useParams();
-  const articleId = id ? `/${id}` : '';
-  const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
-  const [capiId, setCapiId] = useState<string | null>(null);
-  const [selectedImage, setSelectedImage] = useState<ImageObject | null>(null);
-  const scrubbedId = articleId.replace(/^\/+/, '');
+	const { section: id } = useParams();
+	const articleId = id ? `/${id}` : '';
+	const [state, dispatch] = useImmerReducer(recipeReducer, defaultState);
+	const [capiId, setCapiId] = useState<string | null>(null);
+	const [selectedImage, setSelectedImage] = useState<ImageObject | null>(null);
+	const scrubbedId = articleId.replace(/^\/+/, '');
 
-  const [selectedTab, setSelectedTab] = useState('summary');
+	const [selectedTab, setSelectedTab] = useState('summary');
 
-  // idle timer
-  const [remaining, setRemaining] = useState<number>(0);
-  const [openAlert, setOpenAlert] = useState<boolean>(false);
-  const timeout = 180000; // 3 minutes
-  const promptBeforeIdle = 120000; // 2 minutes
-  const navigate = useNavigate();
+	// idle timer
+	const [remaining, setRemaining] = useState<number>(0);
+	const [openAlert, setOpenAlert] = useState<boolean>(false);
+	const timeout = 180000; // 3 minutes
+	const promptBeforeIdle = 120000; // 2 minutes
+	const navigate = useNavigate();
 
-  const onIdle = () => {
-    setOpenAlert(false);
-    navigate('/');
-  };
+	const onIdle = () => {
+		setOpenAlert(false);
+		navigate('/');
+	};
 
-  const onActive = () => {
-    setOpenAlert(false);
-  };
-  const onPrompt = () => {
-    setOpenAlert(true);
-  };
+	const onActive = () => {
+		setOpenAlert(false);
+	};
+	const onPrompt = () => {
+		setOpenAlert(true);
+	};
 
-  const { getRemainingTime, activate } = useIdleTimer({
-    onIdle,
-    onActive,
-    onPrompt,
-    timeout,
-    promptBeforeIdle,
-    throttle: 500,
-  });
+	const { getRemainingTime, activate } = useIdleTimer({
+		onIdle,
+		onActive,
+		onPrompt,
+		timeout,
+		promptBeforeIdle,
+		throttle: 500,
+	});
 
-  const handleStillHere = () => {
-    activate();
-  };
+	const handleStillHere = () => {
+		activate();
+	};
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setRemaining(Math.ceil(getRemainingTime() / 1000));
-    }, 500);
+	useEffect(() => {
+		const interval = setInterval(() => {
+			setRemaining(Math.ceil(getRemainingTime() / 1000));
+		}, 500);
 
-    return () => {
-      clearInterval(interval);
-    };
-  });
+		return () => {
+			clearInterval(interval);
+		};
+	});
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      postRecipe(articleId, state.body)
-        .catch((err) => console.error(err))
-        .then(() =>
-          fetchAndDispatch(
-            `${location.origin}/api/db/${scrubbedId}`,
-            actions.init,
-            'body',
-            dispatch,
-          ),
-        );
-    }, 60000);
-    return () => clearInterval(interval);
-  }, [state]);
+	useEffect(() => {
+		const interval = setInterval(() => {
+			postRecipe(articleId, state.body)
+				.catch((err) => console.error(err))
+				.then(() =>
+					fetchAndDispatch(
+						`${location.origin}/api/db/${scrubbedId}`,
+						actions.init,
+						'body',
+						dispatch,
+					),
+				);
+		}, 60000);
+		return () => clearInterval(interval);
+	}, [state]);
 
-  useEffect(() => {
-    Promise.all([
-      // Get schema
-      fetchAndDispatch(
-        `${location.origin}${apiURL}${schemaEndpoint}`,
-        actions.init,
-        'schema',
-        dispatch,
-      ),
-      // Get parsed recipe items
-      fetchAndDispatch(
-        `${location.origin}/api/db/${scrubbedId}`,
-        actions.init,
-        'body',
-        dispatch,
-      ),
-    ])
-      .then(() => {
-        // Get article content
-        if (state.body === null) {
-          return;
-        }
-        setSelectedImage(state.body.featuredImage);
-        setCapiId(state.body.canonicalArticle);
-        fetchAndDispatch(
-          `${location.origin}${capiProxy}/${state.body.canonicalArticle}`,
-          actions.init,
-          'html',
-          dispatch,
-        );
-        setLoadingFinished(dispatch);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-  }, [articleId, dispatch, state?.body?.canonicalArticle]);
+	useEffect(() => {
+		Promise.all([
+			// Get schema
+			fetchAndDispatch(
+				`${location.origin}${apiURL}${schemaEndpoint}`,
+				actions.init,
+				'schema',
+				dispatch,
+			),
+			// Get parsed recipe items
+			fetchAndDispatch(
+				`${location.origin}/api/db/${scrubbedId}`,
+				actions.init,
+				'body',
+				dispatch,
+			),
+		])
+			.then(() => {
+				// Get article content
+				if (state.body === null) {
+					return;
+				}
+				setSelectedImage(state.body.featuredImage);
+				setCapiId(state.body.canonicalArticle);
+				fetchAndDispatch(
+					`${location.origin}${capiProxy}/${state.body.canonicalArticle}`,
+					actions.init,
+					'html',
+					dispatch,
+				);
+				setLoadingFinished(dispatch);
+			})
+			.catch((err) => {
+				console.error(err);
+			});
+	}, [articleId, dispatch, state?.body?.canonicalArticle]);
 
-  const tabsContent = [
-    {
-      id: 'summary',
-      text: 'Summary',
-      content: <DataPreview recipeData={state.body} />,
-    },
-    {
-      id: 'edit',
-      text: 'Edit',
-      content: (
-        <>
-          <ImagePicker
-            html={state.html}
-            selectedImage={selectedImage}
-            setSelectedImage={setSelectedImage}
-            isLoading={state.isLoading}
-            dispatcher={dispatch}
-          />
-          <form>
-            {state.body && (
-              <RecipeComponent
-                isLoading={state.isLoading}
-                body={state.body}
-                schema={state.schema}
-                dispatcher={dispatch}
-              />
-            )}
-          </form>
-        </>
-      ),
-    },
-  ];
+	const tabsContent = [
+		{
+			id: 'summary',
+			text: 'Summary',
+			content: <DataPreview recipeData={state.body} />,
+		},
+		{
+			id: 'edit',
+			text: 'Edit',
+			content: (
+				<>
+					<ImagePicker
+						html={state.html}
+						selectedImage={selectedImage}
+						setSelectedImage={setSelectedImage}
+						isLoading={state.isLoading}
+						dispatcher={dispatch}
+					/>
+					<form>
+						{state.body && (
+							<RecipeComponent
+								isLoading={state.isLoading}
+								body={state.body}
+								schema={state.schema}
+								dispatcher={dispatch}
+							/>
+						)}
+					</form>
+				</>
+			),
+		},
+	];
 
-  return (
-    <div css={gridLayout}>
-      <div css={footer}>
-        <div
-          className="modal"
-          style={{
-            display: openAlert ? 'flex' : 'none',
-            zIndex: '100',
-            width: '20em',
-            border: '2px solid gray',
-            background: 'white',
-            fontFamily: 'GuardianTextSans',
-            borderRadius: '1em',
-            padding: '1em',
-            position: 'absolute',
-            flexDirection: 'column',
-            alignItems: 'center',
-            left: 'calc(50vw - 10em)',
-            right: 'calc(50vh - 10em)',
-          }}
-        >
-          <h3>Are you still here?</h3>
-          <p>Redirecting in {remaining} seconds</p>
-          <button
-            css={{ fontFamily: 'GuardianTextSans' }}
-            onClick={handleStillHere}
-          >
-            I'm still here!
-          </button>
-        </div>
-        <CurationOptionsBar
-          articleId={articleId}
-          body={state.body}
-          dispatcher={dispatch}
-        />
-      </div>
-      <div css={articleView}>{capiId && <GuFrame articlePath={capiId} />}</div>
-      <div css={dataView}>
-        <Tabs
-          tabsLabel="Toggle between form and preview"
-          tabElement="button"
-          tabs={tabsContent}
-          selectedTab={selectedTab}
-          onTabChange={(tabId: string): void => {
-            setSelectedTab(tabId);
-          }}
-        ></Tabs>
-      </div>
-      <PinboardTrackAndPreselect
-        maybeComposerId={state?.body?.composerId}
-        maybeTitle={state?.body?.title}
-      />
-    </div>
-  );
+	return (
+		<div css={gridLayout}>
+			<div css={footer}>
+				<div
+					className="modal"
+					style={{
+						display: openAlert ? 'flex' : 'none',
+						zIndex: '100',
+						width: '20em',
+						border: '2px solid gray',
+						background: 'white',
+						fontFamily: 'GuardianTextSans',
+						borderRadius: '1em',
+						padding: '1em',
+						position: 'absolute',
+						flexDirection: 'column',
+						alignItems: 'center',
+						left: 'calc(50vw - 10em)',
+						right: 'calc(50vh - 10em)',
+					}}
+				>
+					<h3>Are you still here?</h3>
+					<p>Redirecting in {remaining} seconds</p>
+					<button
+						css={{ fontFamily: 'GuardianTextSans' }}
+						onClick={handleStillHere}
+					>
+						I'm still here!
+					</button>
+				</div>
+				<CurationOptionsBar
+					articleId={articleId}
+					body={state.body}
+					dispatcher={dispatch}
+				/>
+			</div>
+			<div css={articleView}>{capiId && <GuFrame articlePath={capiId} />}</div>
+			<div css={dataView}>
+				<Tabs
+					tabsLabel="Toggle between form and preview"
+					tabElement="button"
+					tabs={tabsContent}
+					selectedTab={selectedTab}
+					onTabChange={(tabId: string): void => {
+						setSelectedTab(tabId);
+					}}
+				></Tabs>
+			</div>
+			<PinboardTrackAndPreselect
+				maybeComposerId={state?.body?.composerId}
+				maybeTitle={state?.body?.title}
+			/>
+		</div>
+	);
 };
 
 export default Curation;

--- a/recipes-client/reducers/recipe-reducer.tsx
+++ b/recipes-client/reducers/recipe-reducer.tsx
@@ -178,12 +178,12 @@ const convertPathStringToArray = (pathString) => {
 };
 
 const reindexStepNumbers = (instructions: Instruction[], draft) => {
-  instructions.forEach((instruction: Instruction, index: number) => {
-    const newStepNumber = index + 1;
-    const keyPathArr = ['instructions', index.toString(), 'stepNumber'];
-    updateStateItem(draft.body, keyPathArr, newStepNumber)
-  })
-}
+	instructions.forEach((instruction: Instruction, index: number) => {
+		const newStepNumber = index + 1;
+		const keyPathArr = ['instructions', index.toString(), 'stepNumber'];
+		updateStateItem(draft.body, keyPathArr, newStepNumber);
+	});
+};
 
 export const recipeReducer = produce(
 	(
@@ -240,8 +240,8 @@ export const recipeReducer = produce(
 					stepNumber: action.payload['stepNumber'] as number,
 				};
 				addStateItem(draft.body, keyPathArr, value);
-        reindexStepNumbers(draft.body.instructions, draft)
-        break;
+				reindexStepNumbers(draft.body.instructions, draft);
+				break;
 			}
 			case actions.selectImg: {
 				updateStateItem(draft.body, ['featuredImage'], action.payload);


### PR DESCRIPTION
## What does this change?

This PR integrates the Grid with Hatch, allowing curators to select and crop any image from its library when selecting featured images. Users can either select the '+' button in the curation view to open an iframe of the [Grid](https://github.com/guardian/grid), or drag and drop images from [Pinboard](https://github.com/guardian/pinboard).

The change means that curators will no longer be bound to the images that appear in a recipe's canonical article when selecting featured images. This has occasionally popped up as a problem because: 

- a) Sometimes recipes don't have an image
- b) The image(s) available don't look great on mobile and could do with being replaced/cropped

@twrichards has masterminded this as a standalone `WithGridSelector` component, which can be wrapped around other elements. This could make it handy for selecting images for steps further down the line.

## How to test

Run locally, select images from the Grid using the UI and also try dragging pics in from Pinboard.

## How can we measure success?

More flexibility and control for curators, better recipe featured images.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1711" alt="image" src="https://github.com/guardian/recipes/assets/11380557/1091a353-5c82-4da9-b910-a044d6ba52d6">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
