### PR TITLE
Workflow integration

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -636,19 +636,10 @@ class ApiController (
 
   def get_list() = Action {
     // Get a list of recipes
-    val partition_alias = "#p"
-    val expressionAttributeValues = MMap(partition_alias -> config.hashKey).asJava
 
-    def scanRequest(tableName: String) = new ScanRequest()
-        .withTableName(tableName)
-        .withProjectionExpression("%s, title, contributors, byline, canonicalArticle, isAppReady, composerId".format(partition_alias))
-        .withExpressionAttributeNames(expressionAttributeValues);
+    val rawResultData = getItems(config.rawRecipesTableName)
 
-    val rawResult = dbClient.scan(scanRequest( config.rawRecipesTableName ));
-    val rawResultData = ItemUtils.toItemList(rawResult.getItems()).asScala
-
-    val curatedResult = dbClient.scan(scanRequest( config.curatedRecipesTableName ));
-    val curatedResultData = ItemUtils.toItemList(curatedResult.getItems()).asScala
+    val curatedResultData = getItems(config.curatedRecipesTableName)
 
     val combinedData = rawResultData.filter( i => !curatedResultData.exists( _.getString(config.hashKey) == i.getString(config.hashKey) ) ) ++ curatedResultData
 

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -636,8 +636,8 @@ class ApiController (
 
   def get_list() = Action {
     // Get a list of recipes
-
-    val rawResultData = getItems(config.rawRecipesTableName)
+    val partition_alias = "#p"
+    val expressionAttributeValues = MMap(partition_alias -> config.hashKey).asJava
 
     def scanRequest(tableName: String) = new ScanRequest()
         .withTableName(tableName)

--- a/recipes-client/components/curation/pinboard-track-and-preselect.tsx
+++ b/recipes-client/components/curation/pinboard-track-and-preselect.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useEffect, useState } from 'react';
+import { workflowContentUrl } from 'utils/workflow';
 
 interface PinboardTrackAndPreselectProps {
 	maybeComposerId: string | undefined;
@@ -15,10 +16,6 @@ export const PinboardTrackAndPreselect = ({
 	useEffect(() => {
 		(async () => {
 			if (!maybeComposerId) return;
-			const workflowDomain = window.location.host
-				.replace('recipes', 'workflow')
-				.replace('.local.', '.code.');
-			const workflowContentUrl = `https://${workflowDomain}/api/content`;
 			const workflowLookupResponse = await fetch(
 				`${workflowContentUrl}/${maybeComposerId}`,
 				{

--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -9,6 +9,7 @@ interface RecipeListProps {
 }
 
 export interface RecipeListType {
+	composerId: string;
 	id: string;
 	title: string;
 	contributors: string[];
@@ -46,8 +47,9 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 	return (
 		<table css={tableStyles}>
 			<colgroup>
-				<col style={{ width: '50%' }} />
+				<col style={{ width: '40%' }} />
 				<col style={{ width: '20%' }} />
+				<col style={{ width: '10%' }} />
 				<col style={{ width: '10%' }} />
 				<col style={{ width: '10%' }} />
 				<col style={{ width: '10%' }} />
@@ -56,6 +58,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 				<tr>
 					<th>Recipe</th>
 					<th>Author(s)</th>
+					<th>Assignee</th>
 					<th>Edited</th>
 					<th>App-ready</th>
 					<th>Actions</th>
@@ -72,6 +75,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 							canonicalArticle,
 							isAppReady,
 							isInCuratedTable,
+							workflow,
 						},
 						i,
 					) => {
@@ -89,6 +93,7 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 								<td key={`path_${i}_author`}>
 									{displayAuthor(contributors, byline)}{' '}
 								</td>
+								<td key={`path_${i}_assignee`}>{workflow?.assignee ?? '-'}</td>
 								<td key={`path_${i}_edited`}>
 									<CheckedSymbol isAppReady={isInCuratedTable} />
 								</td>

--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -5,7 +5,7 @@ import { curationEndpoint } from '../../consts/index';
 import { CheckedSymbol } from '../reusables/app-ready-status';
 
 interface RecipeListProps {
-	list: RecipeListType[];
+	unsortedList: RecipeListType[];
 }
 
 export interface RecipeListType {
@@ -22,7 +22,7 @@ export interface RecipeListType {
 	};
 }
 
-const RecipeList = ({ list: unsortedList }: RecipeListProps): JSX.Element => {
+const RecipeList = ({ unsortedList }: RecipeListProps): JSX.Element => {
 	const list = unsortedList.sort((a, b) =>
 		a.composerId.localeCompare(b.composerId),
 	);
@@ -86,17 +86,17 @@ const RecipeList = ({ list: unsortedList }: RecipeListProps): JSX.Element => {
 						},
 						i,
 					) => {
-						const isDifferentToPreviousComposerId =
+						const isDifferentComposerIdFromPreviousRow =
 							composerId !== list[i - 1]?.composerId;
 						return (
 							<>
-								{isDifferentToPreviousComposerId && (
+								{isDifferentComposerIdFromPreviousRow && (
 									<tr
 										css={css`
 											background-color: #eee;
 										`}
 									>
-										<td colSpan={6} key={`path_${i}_title`}>
+										<td colSpan={6} key={`path_${i}_path`}>
 											<a
 												href={`https://theguardian.co.uk/${canonicalArticle}`}
 												target="_blank"
@@ -149,7 +149,7 @@ const tableStyles = css`
 	text-align: left;
 	th,
 	td {
-		padding: 0.5rem; // TODO: Get rid
+		padding: 0.5rem;
 		border-bottom: 1px solid #ccc;
 	}
 	th {

--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -17,9 +17,15 @@ export interface RecipeListType {
 	canonicalArticle: string;
 	isAppReady: boolean;
 	isInCuratedTable: boolean;
+	workflow?: {
+		assignee: string;
+	};
 }
 
-const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
+const RecipeList = ({ list: unsortedList }: RecipeListProps): JSX.Element => {
+	const list = unsortedList.sort((a, b) =>
+		a.composerId.localeCompare(b.composerId),
+	);
 	const displayAuthor = (contributors: string[], byline: string[]) => {
 		const prettifyContributorId = (contributorId: string) => {
 			if (contributorId === 'profile/yotamottolenghi') {
@@ -76,34 +82,58 @@ const RecipeList = ({ list }: RecipeListProps): JSX.Element => {
 							isAppReady,
 							isInCuratedTable,
 							workflow,
+							composerId,
 						},
 						i,
 					) => {
+						const isDifferentToPreviousComposerId =
+							composerId !== list[i - 1]?.composerId;
 						return (
-							<tr key={`row_${i}`}>
-								<td key={`path_${i}_title`}>
-									<a
-										href={`https://theguardian.com/${canonicalArticle}`}
-										target="_blank"
+							<>
+								{isDifferentToPreviousComposerId && (
+									<tr
+										css={css`
+											background-color: #eee;
+										`}
 									>
-										{title}{' '}
-										<SvgExternal isAnnouncedByScreenReader size="xsmall" />
-									</a>
-								</td>
-								<td key={`path_${i}_author`}>
-									{displayAuthor(contributors, byline)}{' '}
-								</td>
-								<td key={`path_${i}_assignee`}>{workflow?.assignee ?? '-'}</td>
-								<td key={`path_${i}_edited`}>
-									<CheckedSymbol isAppReady={isInCuratedTable} />
-								</td>
-								<td key={`path_${i}_app`}>
-									<CheckedSymbol isAppReady={isAppReady} />
-								</td>
-								<td key={`path_${i}_links`}>
-									<a href={curationEndpoint + '/' + id}>Edit</a>
-								</td>
-							</tr>
+										<td colSpan={6} key={`path_${i}_title`}>
+											<a
+												href={`https://theguardian.co.uk/${canonicalArticle}`}
+												target="_blank"
+											>
+												{canonicalArticle}{' '}
+												<SvgExternal isAnnouncedByScreenReader size="xsmall" />
+											</a>
+										</td>
+									</tr>
+								)}
+								<tr key={`row_${i}`}>
+									<td key={`path_${i}_title`}>
+										<span
+											css={css`
+												padding-left: 2rem;
+											`}
+										>
+											{title}
+										</span>
+									</td>
+									<td key={`path_${i}_author`}>
+										{displayAuthor(contributors, byline)}{' '}
+									</td>
+									<td key={`path_${i}_assignee`}>
+										{workflow?.assignee ? workflow.assignee.split('@')[0] : '-'}
+									</td>
+									<td key={`path_${i}_edited`}>
+										<CheckedSymbol isAppReady={isInCuratedTable} />
+									</td>
+									<td key={`path_${i}_app`}>
+										<CheckedSymbol isAppReady={isAppReady} />
+									</td>
+									<td key={`path_${i}_links`}>
+										<a href={curationEndpoint + '/' + id}>Edit</a>
+									</td>
+								</tr>
+							</>
 						);
 					},
 				)}
@@ -119,12 +149,12 @@ const tableStyles = css`
 	text-align: left;
 	th,
 	td {
-		padding: 0.5rem;
+		padding: 0.5rem; // TODO: Get rid
 		border-bottom: 1px solid #ccc;
 	}
 	th {
 		font-weight: bold;
-		background-color: #eee;
+		background-color: lightgray;
 	}
 `;
 

--- a/recipes-client/components/form/form-group.tsx
+++ b/recipes-client/components/form/form-group.tsx
@@ -195,7 +195,9 @@ export const FormGroup = ({
 	const key = key_ || title;
 	const formDispatcher = dispatcher || null;
 
-	const [instructionsToMerge, setInstructionsToMerge] = useState<ModifiedInstruction[]>([]);
+	const [instructionsToMerge, setInstructionsToMerge] = useState<
+		ModifiedInstruction[]
+	>([]);
 	const [checkedFields, setCheckedFields] = useState({});
 
 	const toggleInstructionsToMerge = (
@@ -208,14 +210,18 @@ export const FormGroup = ({
 			objId: key,
 		};
 		if (e?.target.checked) {
-			setInstructionsToMerge((instructions) => [...instructions, modifiedInstruction]);
+			setInstructionsToMerge((instructions) => [
+				...instructions,
+				modifiedInstruction,
+			]);
 		} else {
 			setInstructionsToMerge((instructions) =>
-				instructions.filter((instruction) => instruction.objId !== modifiedInstruction.objId),
+				instructions.filter(
+					(instruction) => instruction.objId !== modifiedInstruction.objId,
+				),
 			);
 		}
 	};
-
 
 	// Set up form group
 	const rComponents =
@@ -262,7 +268,7 @@ export const FormGroup = ({
 
 		setInstructionsToMerge([]);
 
-    // De-select checkboxes previously selected after the merge
+		// De-select checkboxes previously selected after the merge
 		const resetCheckedFields = { ...checkedFields };
 		Object.keys(resetCheckedFields).forEach((key) => {
 			resetCheckedFields[key] = false;
@@ -278,15 +284,18 @@ export const FormGroup = ({
 					type="button"
 					onClick={() => mergeInstructions()}
 					disabled={instructionsToMerge.length < 2}
-          style={{fontSize: '0.9375rem',
-            fontWeight: instructionsToMerge.length >= 2 ? '800' : '400',
-            fontFamily: 'GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif',
-            color: instructionsToMerge.length >= 2 ? '#fff' : 'gray',
-            width: '150px',
-            background: instructionsToMerge.length >= 2 ? '#052962' : 'transparent', // Change background based on condition
-            padding: '8px',
-            cursor: instructionsToMerge.length >= 2 ? 'pointer' : 'default'
-          }}
+					style={{
+						fontSize: '0.9375rem',
+						fontWeight: instructionsToMerge.length >= 2 ? '800' : '400',
+						fontFamily:
+							'GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif',
+						color: instructionsToMerge.length >= 2 ? '#fff' : 'gray',
+						width: '150px',
+						background:
+							instructionsToMerge.length >= 2 ? '#052962' : 'transparent', // Change background based on condition
+						padding: '8px',
+						cursor: instructionsToMerge.length >= 2 ? 'pointer' : 'default',
+					}}
 				>
 					Merge instructions
 				</button>

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -23,7 +23,15 @@ const Home = (): JSX.Element => {
 			fetch(`${workflowContentUrl}?section=Recipes+Data`, {
 				credentials: 'include',
 			})
-				.then((response) => response.json())
+				.then((response) => {
+					if (response.ok) {
+						return response.json();
+					} else {
+						throw new Error(
+							`Error fetching workflow content: ${response.statusText}`,
+						);
+					}
+				})
 				.then(({ content }) => {
 					setWorkflowLookup(
 						Object.values(content)
@@ -53,17 +61,17 @@ const Home = (): JSX.Element => {
 		() =>
 			recipeList
 				.filter((recipe) => {
-					if (listFilter === 'all') {
-						return true;
-					} else if (listFilter === 'app-ready') {
-						return recipe.isAppReady;
-					} else if (listFilter === 'edited-but-not-app-ready') {
-						return !recipe.isAppReady && recipe.isInCuratedTable;
-					} else if (listFilter === 'non-curated') {
-						return !recipe.isAppReady && !recipe.isInCuratedTable;
-					} else {
-						console.error('Invalid filter');
-						return true;
+					switch (listFilter) {
+						case 'all':
+							return true;
+						case 'app-ready':
+							return recipe.isAppReady;
+						case 'edited-but-not-app-ready':
+							return !recipe.isAppReady && recipe.isInCuratedTable;
+						case 'non-curated':
+							return !recipe.isAppReady && !recipe.isInCuratedTable;
+						default:
+							return true;
 					}
 				})
 				.map((recipe) => ({
@@ -157,7 +165,9 @@ const Home = (): JSX.Element => {
 					/>
 				</RadioGroup>
 			</div>
-			{recipeList.length > 0 && <RecipeList list={displayedRecipeList} />}
+			{recipeList.length > 0 && (
+				<RecipeList unsortedList={displayedRecipeList} />
+			)}
 		</div>
 	);
 };

--- a/recipes-client/utils/workflow.ts
+++ b/recipes-client/utils/workflow.ts
@@ -1,0 +1,9 @@
+const workflowDomain = window.location.host
+	.replace('recipes', 'workflow')
+	.replace('.local.', '.code.');
+
+export const workflowContentUrl = `https://${workflowDomain}/api/content`;
+
+export interface WorkflowLookup {
+	[composerId: string]: { assignee: string; status: string };
+}


### PR DESCRIPTION
## What does this change?

This PR uses Composer IDs to connect the worlds of Hatch and Workflow. By using the `composerId` field of the recipe data we're able to assign people to canonical articles, a change which should make multiple curators much more feasible. 

If someone is assigned to a recipe article in Workflow, that will surface in the Hatch dashboard for every recipe within that article. Recipes are now also grouped together based on whether they share the same canonical article.

![image](https://github.com/guardian/recipes/assets/11380557/354e3ffb-cbe8-4bc0-8d41-1b97b8a70da4)

The changes here build on work done while integrating Pinboard (#65) and together with (#114) leaves us well positioned to start onboarding other members of editorial if we want to. 

## How to test

Run locally, change assignees to articles in CODE Workflow, and see if that reflects in Hatch. 

## How can we measure success?

Clear assignee system for curating recipes that gives editorial a familiar birds-eye view of what's being worked on. Integration with existing systems rather than making new bespoke ones.
