### PR TITLE
Handle undefined `composerId` field when sorting recipe list

### DIFF
--- a/recipes-client/components/dashboard/recipe-list.tsx
+++ b/recipes-client/components/dashboard/recipe-list.tsx
@@ -24,7 +24,11 @@ export interface RecipeListType {
 
 const RecipeList = ({ unsortedList }: RecipeListProps): JSX.Element => {
 	const list = unsortedList.sort((a, b) =>
-		a.composerId.localeCompare(b.composerId),
+		a.composerId === undefined
+			? -1
+			: b.composerId === undefined
+			? 1
+			: a.composerId.localeCompare(b.composerId),
 	);
 	const displayAuthor = (contributors: string[], byline: string[]) => {
 		const prettifyContributorId = (contributorId: string) => {


### PR DESCRIPTION
Addresses a bug that snuck through #119.