### PR TITLE
UI tweaks: Move horizontal scroll bar to top of ingredient sections, remove successful save popups

### DIFF
--- a/recipes-client/components/curation/curation-options-bar.tsx
+++ b/recipes-client/components/curation/curation-options-bar.tsx
@@ -43,8 +43,6 @@ export const postRecipe = async (
 			alert(
 				'Oops, a hiccup in the kitchen, recipe was not saved, sorry 😢\nPlease contact engineers if problem persists 🚑',
 			);
-		} else {
-			alert('Successfully saved and ready to be cooked! 🍲✨');
 		}
 	} catch (error) {
 		console.error(error);

--- a/recipes-client/components/form/inputs/ingredients.tsx
+++ b/recipes-client/components/form/inputs/ingredients.tsx
@@ -12,6 +12,7 @@ import FormItem from '../form-item';
 import { renderRangeFormGroup } from './range';
 import { actions } from 'actions/recipeActions';
 import { getFormFieldsSchema } from '../form-group';
+import { css } from '@emotion/react';
 
 export const renderIngredientsFormGroup = (
 	formItems: IngredientsGroup,
@@ -139,9 +140,22 @@ export const renderIngredientsFormGroup = (
 		}
 	});
 	return [
-		<div>
-			{fields}
-			{formItemButtons}
+		<div
+			css={css`
+				overflow-x: scroll;
+				overflow-y: auto;
+				transform: rotateX(180deg);
+				margin-bottom: 20px;
+			`}
+		>
+			<div
+				css={css`
+					transform: rotateX(180deg);
+				`}
+			>
+				{fields}
+				{formItemButtons}
+			</div>
 		</div>,
 	];
 };


### PR DESCRIPTION
## What does this change?

This applies some feedback/suggestions from Chloe Kirton after shadowing Anna B. The PR applies a couple of small changes:

- The horizontal scroll bar has been moved to the top of each individual ingredient group, rather than the bottom of the overall section
- The successful save pop-up has been removed as the autosave was making it a frustration. It was implemented in part due to saving issues but it's been long enough since that's been a problem that this feels safe to remove

<img width="1685" alt="image" src="https://github.com/guardian/recipes/assets/11380557/41998897-a7aa-46a5-9654-8e528d300547">


