### PR TITLE
Direct visitors to Composer on homepage

### DIFF
--- a/recipes-client/components/dashboard/welcome-explainer.tsx
+++ b/recipes-client/components/dashboard/welcome-explainer.tsx
@@ -1,22 +1,35 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+
 export const WelcomeExplainer = () => {
 	return (
-		<div>
-			<h2>This is it how it works:</h2>
+		<div
+			css={css`
+				${textSans.medium()};
+				margin: 0 auto;
+				li {
+					margin-bottom: 10px;
+				}
+			`}
+		>
+			<h2>Welcome to Hatch! Now, please leave Hatch.</h2>
+			<p>
+				The altogether more functional, stylish, and dignified{' '}
+				<a href="https://composer.gutools.co.uk/">Composer</a> is the new home
+				of recipe data curation.
+			</p>
+			<p>To create a recipe in Composer:</p>
 			<ul>
-				<li>Pick a recipe.</li>
-				<li>Edit it.</li>
-				<li>Save it.</li>
+				<li>Open a recipe article (ensuring it has a 'tone/recipes' tag)</li>
+				<li>Highlight the content of the recipe you want to structure</li>
+				<li>Click the 'Create Recipe' button that appears</li>
+				<li>Curate and save</li>
 			</ul>
-			<div>
-				Read the{' '}
-				<a
-					href="https://docs.google.com/document/d/1wrVUX7vVTLBd0fxqDbQxqmyXoY4Vvyw5aX79tMxROhk/edit#heading=h.7n6l8nswve9p"
-					target="_blank"
-				>
-					recipe data curation guide
-				</a>{' '}
-				for a more in-depth breakdown.
-			</div>
+			<p>
+				Hatch itself may yet return as a recipe data summary dashboard, but for
+				now it's time to say goodbye.
+			</p>
 		</div>
 	);
 };

--- a/recipes-client/components/layout/header.tsx
+++ b/recipes-client/components/layout/header.tsx
@@ -25,7 +25,7 @@ const Header = (): JSX.Element => {
 		>
 			<a href="/">
 				<h2>Hatch</h2>
-				<span>A (temporary) recipe data curation tool</span>
+				<span>Formerly a (temporary) recipe data curation tool</span>
 			</a>
 		</header>
 	);

--- a/recipes-client/pages/home.tsx
+++ b/recipes-client/pages/home.tsx
@@ -1,173 +1,20 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { palette } from '@guardian/source-foundations';
-import { Radio, RadioGroup } from '@guardian/source-react-components';
-import { RecipesOverview } from 'components/dashboard/recipes-overview';
-import { useEffect, useMemo, useState } from 'react';
-import RecipeList, {
-	RecipeListType,
-} from '../components/dashboard/recipe-list';
-import { listEndpoint } from '../consts/index';
 import { WelcomeExplainer } from 'components/dashboard/welcome-explainer';
-import { WorkflowLookup, workflowContentUrl } from 'utils/workflow';
 
 const Home = (): JSX.Element => {
-	const [recipeList, setRecipeList] = useState<RecipeListType[]>([]);
-	const [listFilter, setListFilter] = useState<
-		'all' | 'app-ready' | 'edited-but-not-app-ready' | 'non-curated'
-	>('all');
-
-	const [workflowLookup, setWorkflowLookup] = useState<WorkflowLookup>({});
-	useEffect(() => {
-		const populateWorkflowLookup = () => {
-			fetch(`${workflowContentUrl}?section=Recipes+Data`, {
-				credentials: 'include',
-			})
-				.then((response) => {
-					if (response.ok) {
-						return response.json();
-					} else {
-						throw new Error(
-							`Error fetching workflow content: ${response.statusText}`,
-						);
-					}
-				})
-				.then(({ content }) => {
-					setWorkflowLookup(
-						Object.values(content)
-							.flat()
-							.reduce(
-								(acc, { composerId, assignee, status }) => ({
-									...acc,
-									[composerId]: {
-										assignee,
-										status,
-									},
-								}),
-								{} as WorkflowLookup,
-							),
-					);
-				})
-				.catch(console.error);
-		};
-		populateWorkflowLookup();
-		setInterval(
-			populateWorkflowLookup,
-			5000, // Five seconds to match Workflow polling frequency
-		);
-	}, []);
-
-	const displayedRecipeList = useMemo(
-		() =>
-			recipeList
-				.filter((recipe) => {
-					switch (listFilter) {
-						case 'all':
-							return true;
-						case 'app-ready':
-							return recipe.isAppReady;
-						case 'edited-but-not-app-ready':
-							return !recipe.isAppReady && recipe.isInCuratedTable;
-						case 'non-curated':
-							return !recipe.isAppReady && !recipe.isInCuratedTable;
-						default:
-							return true;
-					}
-				})
-				.map((recipe) => ({
-					...recipe,
-					workflow: workflowLookup[recipe.composerId],
-				})),
-
-		[recipeList, listFilter, workflowLookup],
-	);
-
-	useEffect(() => {
-		fetch(listEndpoint)
-			.then((response) => response.json())
-			.then((data) => setRecipeList(data))
-			.catch(() => null);
-	}, []);
-
-	const counterStyles = css`
-		position: fixed;
-		top: 0;
-		right: 0;
-		background-color: ${palette.brandAlt[300]};
-		padding: 10px;
-		font-size: 1.2rem;
-		font-weight: bold;
-		color: #121212;
-		border-bottom-left-radius: 5px;
-		z-index: 1;
-	`;
-
 	return (
 		<div css={mainContainerStyles}>
-			<div css={counterStyles}>
-				<div>
-					<span>{recipeList.filter((recipe) => recipe.isAppReady).length}</span>{' '}
-					app-approved recipes and counting
-				</div>
-			</div>
 			<div
 				css={css`
-					display: flex;
-					flex-direction: row;
-					justify-content: space-between;
+					position: absolute;
+					top: 50%;
+					left: 50%;
+					transform: translate(-50%, -50%);
 				`}
 			>
-				<div
-					css={css`
-						width: 33%;
-					`}
-				>
-					<WelcomeExplainer />
-				</div>
-				<div
-					css={css`
-						width: 67%;
-					`}
-				>
-					<RecipesOverview recipesList={recipeList} />
-				</div>
+				<WelcomeExplainer />
 			</div>
-			<hr />
-			<div>
-				<RadioGroup orientation="horizontal" label="Filter displayed recipes">
-					<Radio
-						name="filter"
-						value="all"
-						label="All"
-						onChange={() => setListFilter('all')}
-						checked={listFilter === 'all'}
-					/>
-					<Radio
-						name="filter"
-						value="app-ready"
-						label="App-approved"
-						onChange={() => setListFilter('app-ready')}
-						checked={listFilter === 'app-ready'}
-					/>
-					<Radio
-						name="filter"
-						value="edited-but-not-app-ready"
-						label="Edited but not app-approved"
-						onChange={() => setListFilter('edited-but-not-app-ready')}
-						checked={listFilter === 'edited-but-not-app-ready'}
-					/>
-					<Radio
-						name="filter"
-						value="non-curated"
-						label="Awaiting curation"
-						onChange={() => setListFilter('non-curated')}
-						checked={listFilter === 'non-curated'}
-					/>
-				</RadioGroup>
-			</div>
-			{recipeList.length > 0 && (
-				<RecipeList unsortedList={displayedRecipeList} />
-			)}
 		</div>
 	);
 };


### PR DESCRIPTION
The time has come. This is the PR to merge when we formally switch from Hatch to Composer as the home of recipe data curation. With this change the homepage simply displays a message directing onwards:

<img width="1720" alt="image" src="https://github.com/guardian/recipes/assets/11380557/bd937e42-f890-4869-881f-61f8eaa827ec">

I've left some of the other code in on the off-chance we need to roll back, but it's unlikely.

Once the dust has settled maybe Hatch can enjoy new life as a recipe data dashboard...